### PR TITLE
add support for hierachical job model (ItemGroup)

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/ConfigInfo.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ConfigInfo.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jobConfigHistory;
 
+import hudson.model.AbstractItem;
 import hudson.model.AbstractProject;
 
 import java.io.File;
@@ -43,7 +44,7 @@ public class ConfigInfo {
     /**
      * Returns a new ConfigInfo object for a Hudson job.
      *
-     * @param job
+     * @param item
      *            a project
      * @param file
      *            pointing to {@code config.xml}
@@ -54,10 +55,10 @@ public class ConfigInfo {
      * @throws UnsupportedEncodingException
      *             if UTF-8 is not available (probably a serious error).
      */
-    public static ConfigInfo create(final AbstractProject<?, ?> job, final File file, final HistoryDescr histDescr)
+    public static ConfigInfo create(final AbstractItem item, final File file, final HistoryDescr histDescr)
         throws UnsupportedEncodingException {
         return new ConfigInfo(
-                job.getName(),
+                item.getName(),
                 URLEncoder.encode(file.getAbsolutePath(), "utf-8"),
                 histDescr.getTimestamp(),
                 histDescr.getUser(),

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -4,6 +4,7 @@ import hudson.Plugin;
 import hudson.XmlFile;
 import hudson.model.AbstractProject;
 import hudson.model.Hudson;
+import hudson.model.ItemGroup;
 import hudson.model.Saveable;
 import hudson.model.Descriptor.FormException;
 import hudson.util.FormValidation;
@@ -46,6 +47,9 @@ public class JobConfigHistory extends Plugin {
      */
     private boolean saveSystemConfiguration;
 
+    /** Flag to indicated ItemGroups configuration is saved as well */
+    private boolean saveItemGroupConfiguration;
+
     /** Flag to indicate if we should save history when it 
      *  is a duplication of the previous saved configuration.
      */
@@ -84,6 +88,7 @@ public class JobConfigHistory extends Plugin {
         historyRootDir = formData.getString("historyRootDir").trim();
         maxHistoryEntries = formData.getString("maxHistoryEntries").trim();
         saveSystemConfiguration = formData.getBoolean("saveSystemConfiguration");
+        saveItemGroupConfiguration = formData.getBoolean("saveItemGroupConfiguration");
         skipDuplicateHistory = formData.getBoolean("skipDuplicateHistory");
         excludePattern = formData.getString("excludePattern");
         save();
@@ -118,6 +123,10 @@ public class JobConfigHistory extends Plugin {
      */
     public boolean getSaveSystemConfiguration() {
         return saveSystemConfiguration;
+    }
+
+    public boolean getSaveItemGroupConfiguration() {
+        return saveItemGroupConfiguration;
     }
 
     /**
@@ -309,6 +318,8 @@ public class JobConfigHistory extends Plugin {
             } else {
                 saveable = true;
             }
+        } else if (saveItemGroupConfiguration && item instanceof ItemGroup) {
+            saveable = true;
         }
         if (saveable && skipDuplicateHistory && hasDuplicateHistory(xmlFile)) {
             LOG.fine("found duplicate history, skipping save of " + xmlFile);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryJobListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryJobListener.java
@@ -3,7 +3,7 @@ package hudson.plugins.jobConfigHistory;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Item;
-import hudson.model.AbstractProject;
+import hudson.model.AbstractItem;
 import hudson.model.Hudson;
 import hudson.model.listeners.ItemListener;
 
@@ -29,10 +29,10 @@ public final class JobConfigHistoryJobListener extends ItemListener {
     @Override
     public void onCreated(Item item) {
         LOG.finest("In onCreated for " + item);
-        if (item instanceof AbstractProject<?, ?>) {
-            ConfigHistoryListenerHelper.CREATED.createNewHistoryEntry(((AbstractProject<?, ?>) item).getConfigFile());
+        if (item instanceof AbstractItem) {
+            ConfigHistoryListenerHelper.CREATED.createNewHistoryEntry(((AbstractItem) item).getConfigFile());
         } else {
-            LOG.finest("onCreated: not an AbstractProject, skipping history save");
+            LOG.finest("onCreated: not an AbstractItem, skipping history save");
         }
         LOG.finest("onCreated for " + item + " done.");
         //        new Exception("STACKTRACE for double invocation").printStackTrace();
@@ -48,14 +48,14 @@ public final class JobConfigHistoryJobListener extends ItemListener {
     public void onRenamed(Item item, String oldName, String newName) {
         final String onRenameDesc = " old name: " + oldName + ", new name: " + newName;
         LOG.finest("In onRenamed for " + item + onRenameDesc);
-        if (item instanceof AbstractProject<?, ?>) {
-            ConfigHistoryListenerHelper.RENAMED.createNewHistoryEntry(((AbstractProject<?, ?>) item).getConfigFile());
+        if (item instanceof AbstractItem) {
+            ConfigHistoryListenerHelper.RENAMED.createNewHistoryEntry(((AbstractItem) item).getConfigFile());
             final JobConfigHistory plugin = Hudson.getInstance().getPlugin(JobConfigHistory.class);
 
             // move history items from previous name, if the directory exists
             // only applies if using a custom root directory for saving history
             if (plugin.getConfiguredHistoryRootDir() != null) {
-                final File currentHistoryDir = plugin.getHistoryDir(((AbstractProject<?, ?>) item).getConfigFile());
+                final File currentHistoryDir = plugin.getHistoryDir(((AbstractItem) item).getConfigFile());
                 final File historyParentDir = currentHistoryDir.getParentFile();
                 final File oldHistoryDir = new File(historyParentDir, oldName);
                 if (oldHistoryDir.exists()) {
@@ -83,7 +83,7 @@ public final class JobConfigHistoryJobListener extends ItemListener {
     @Override
     public void onDeleted(Item item) {
         LOG.finest("In onDeleted for " + item);
-        if (item instanceof AbstractProject<?, ?>) {
+        if (item instanceof AbstractItem) {
             final JobConfigHistory plugin = Hudson.getInstance().getPlugin(JobConfigHistory.class);
 
             // At this point, the /jobs/<job> directory has been deleted.  We do not want to take any
@@ -92,8 +92,8 @@ public final class JobConfigHistoryJobListener extends ItemListener {
             //
             // Also rename history directory to <job>_deleted_<timestamp> - should be a safe 'unique' name
             if (plugin.getConfiguredHistoryRootDir() != null) {
-                ConfigHistoryListenerHelper.DELETED.createNewHistoryEntry(((AbstractProject<?, ?>) item).getConfigFile());
-                final File currentHistoryDir = plugin.getHistoryDir(((AbstractProject<?, ?>) item).getConfigFile());
+                ConfigHistoryListenerHelper.DELETED.createNewHistoryEntry(((AbstractItem) item).getConfigFile());
+                final File currentHistoryDir = plugin.getHistoryDir(((AbstractItem) item).getConfigFile());
 
                 final SimpleDateFormat buildDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss_SSS");
                 final String timestamp = buildDateFormat.format(new Date());

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -1,6 +1,7 @@
 package hudson.plugins.jobConfigHistory;
 
 import hudson.XmlFile;
+import hudson.model.AbstractItem;
 import hudson.model.AbstractProject;
 import hudson.security.AccessControlled;
 
@@ -23,18 +24,18 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @param project
      *            for which configurations should be returned.
      */
-    public JobConfigHistoryProjectAction(AbstractProject<?, ?> project) {
+    public JobConfigHistoryProjectAction(AbstractItem project) {
         super();
         this.project = project;
     }
 
     /** The project. */
-    private final transient AbstractProject<?, ?> project;
+    private final transient AbstractItem project;
 
     /**
-     * Returns the configuration history entries for one {@link AbstractProject}.
+     * Returns the configuration history entries for one {@link AbstractItem}.
      *
-     * @return history list for one {@link AbstractProject}.
+     * @return history list for one {@link AbstractItem}.
      * @throws IOException
      *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
      */
@@ -61,7 +62,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      *
      * @return project
      */
-    public final AbstractProject<?, ?> getProject() {
+    public final AbstractItem getProject() {
         return project;
     }
 

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -2,7 +2,7 @@ package hudson.plugins.jobConfigHistory;
 
 import hudson.Extension;
 import hudson.XmlFile;
-import hudson.model.AbstractProject;
+import hudson.model.AbstractItem;
 import hudson.model.Hudson;
 import hudson.model.RootAction;
 import hudson.security.AccessControlled;
@@ -37,9 +37,9 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction imple
     }
 
     /**
-     * Returns the configuration history entries for all {@link AbstractProject}s and System files in this Hudson instance.
+     * Returns the configuration history entries for all {@link AbstractItem}s and System files in this Hudson instance.
      *
-     * @return list for all {@link AbstractProject}s.
+     * @return list for all {@link AbstractItem}s.
      * @throws IOException
      *             if one of the history entries might not be read.
      */
@@ -49,12 +49,12 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction imple
         // we don't display any project info if we are filtered (applies to system configuration only)
         if (filter == null) {
             @SuppressWarnings("unchecked")
-            final List<AbstractProject> projects = Hudson.getInstance().getItems(AbstractProject.class);
-            for (final AbstractProject<?, ?> project : projects) {
-                LOG.finest("getConfigs: Getting configs for " + project.getName());
-                final JobConfigHistoryProjectAction action = new JobConfigHistoryProjectAction(project);
+            final List<AbstractItem> items = Hudson.getInstance().getAllItems(AbstractItem.class);
+            for (final AbstractItem item : items) {
+                LOG.finest("getConfigs: Getting configs for " + item.getFullName());
+                final JobConfigHistoryProjectAction action = new JobConfigHistoryProjectAction(item);
                 final List<ConfigInfo> jobConfigs = action.getConfigs();
-                LOG.finest("getConfigs: " + project.getName() + " has " + jobConfigs.size() + " history items");
+                LOG.finest("getConfigs: " + item.getFullName() + " has " + jobConfigs.size() + " history items");
                 configs.addAll(jobConfigs);
             }
         }

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistory/config.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistory/config.jelly
@@ -8,6 +8,9 @@
         <f:textbox name="maxHistoryEntries" value="${it.maxHistoryEntries}"
            checkUrl="'${rootURL}/plugin/jobConfigHistory/checkMaxHistoryEntries?value='+escape(this.value)"/>
       </f:entry>
+      <f:entry title="${%Save ItemGroups configuration changes}" help="/plugin/jobConfigHistory/help/help-saveItemGroupConfiguration.html">
+        <f:checkbox name="saveItemGroupConfiguration" checked="${it.saveItemGroupConfiguration}"/>
+      </f:entry>
       <f:entry title="${%Save system configuration changes}" help="/plugin/jobConfigHistory/help/help-saveSystemConfiguration.html">
         <f:checkbox name="saveSystemConfiguration" checked="${it.saveSystemConfiguration}"/>
       </f:entry>

--- a/src/main/webapp/help/help-saveItemGroupConfiguration.html
+++ b/src/main/webapp/help/help-saveItemGroupConfiguration.html
@@ -1,0 +1,3 @@
+Save configuration files for ItemGroups.
+
+


### PR DESCRIPTION
ItemGroup used to store Job in a hierarchical model (typically: cloudbees folders plugin) also have configuration that should be saved in history. This pull request add support for them using a new configuration parameter to enable this feature
