### PR TITLE
Support storing job config history in folders

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/ConfigInfo.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ConfigInfo.java
@@ -57,7 +57,7 @@ public class ConfigInfo {
     public static ConfigInfo create(final AbstractItem item, final File file, final HistoryDescr histDescr)
         throws UnsupportedEncodingException {
         return new ConfigInfo(
-                item.getName(),
+                item.getFullName(),
                 URLEncoder.encode(file.getAbsolutePath(), "utf-8"),
                 histDescr.getTimestamp(),
                 histDescr.getUser(),

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
@@ -149,7 +149,7 @@ public class JobConfigBadgeAction extends RunListener<AbstractBuild> implements 
         final JobConfigHistory plugin = Hudson.getInstance().getPlugin(JobConfigHistory.class);
         
         for (String timestamp : configDates) {
-            final String path = plugin.getJobHistoryRootDir() + "/" + build.getProject().getName() + "/" + timestamp;
+            final String path = plugin.getJobHistoryRootDir() + "/" + build.getProject().getFullName().replace("/", "/jobs/") + "/" + timestamp;
             final File historyDir = new File(path);
             if (!historyDir.exists() || !new File(historyDir, "config.xml").exists()) {
                 return false;

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryJobListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryJobListener.java
@@ -91,7 +91,7 @@ public final class JobConfigHistoryJobListener extends ItemListener {
 
             final SimpleDateFormat buildDateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss_SSS");
             final String timestamp = buildDateFormat.format(new Date());
-            final String deletedHistoryName = item.getName() + JobConfigHistoryConsts.DELETED_MARKER + timestamp;
+            final String deletedHistoryName = item.getFullName().replace("/", "/jobs/") + JobConfigHistoryConsts.DELETED_MARKER + timestamp;
             final File deletedHistoryDir = new File(currentHistoryDir.getParentFile(), deletedHistoryName);
             
             if (!currentHistoryDir.renameTo(deletedHistoryDir)) {

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -186,10 +186,10 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
         
         if (checkTimestamp(timestamp)) {
             if (project instanceof MavenModule) {
-                path = rootDir + ((MavenModule) project).getParent().getName() + "/modules/" 
+                path = rootDir + ((MavenModule) project).getParent().getFullName().replace("/", "/jobs/") + "/modules/"
                         + ((MavenModule) project).getModuleName().toFileSystemName() + "/" + timestamp;
             } else {
-                path = rootDir + project.getName() + "/" + timestamp;
+                path = rootDir + project.getFullName().replace("/", "/jobs/") + "/" + timestamp;
             }
             configFile = getPlugin().getConfigFile(new File(path));
         }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -240,7 +240,7 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction imple
     public final String createLinkToJobFiles(ConfigInfo config, String type) {
         final String link;
         if (config.getIsJob() && !config.getJob().contains(JobConfigHistoryConsts.DELETED_MARKER)) {
-            link = getHudson().getRootUrl() + "job/" + config.getJob() + getUrlName() 
+            link = getHudson().getRootUrl() + "job/" + config.getJob().replace("/", "/job/") + getUrlName()
                     + "/configOutput?type=" + type + "&timestamp=" + config.getDate();
         } else {
             link = "configOutput?type=" + type + "&name=" + config.getJob() + "&timestamp=" + config.getDate();


### PR DESCRIPTION
This plugin seems to be completely broken with respect to the CloudBees Folders plugin (or generally with `ItemGroup`s other than `Jenkins` itself). I suspect this is a regression caused by the recent refactorings.

Functional testing using `MockFolder` only possible when using a core dependency ≥ 1.494.

The patch here should be considered a hotfix: it just hardcodes the fact that `jobs` is the directory separator for folders and `job` is the URL separator. (These names match those defined in Jenkins core.) For the directory separator issue, probably `AbstractItem.getConfigFile` or `PersistenceRoot.getRootDir` should be used rather than the current hack of `JOBS_HISTORY_DIR`. For the URL separator issue, `AbstractItem.getUrl` is probably what you want.
