### PR TITLE
JENKINS-18473 - Change History cosumes extreme amounts of CPU

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -15,6 +15,7 @@ import java.io.FileFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -440,7 +441,7 @@ public class JobConfigHistory extends Plugin {
      */
     private boolean checkDuplicate(final XmlFile xmlFile) {
         if (skipDuplicateHistory && hasDuplicateHistory(xmlFile)) {
-            LOG.fine("found duplicate history, skipping save of " + xmlFile);
+            LOG.log(Level.FINE, "found duplicate history, skipping save of {0}", xmlFile);
             return false;
         } else {
             return true;

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryActionFactory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryActionFactory.java
@@ -8,6 +8,7 @@ import hudson.model.TransientProjectActionFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -29,10 +30,10 @@ public class JobConfigHistoryActionFactory extends TransientProjectActionFactory
     public Collection<? extends Action> createFor(@SuppressWarnings("unchecked") AbstractProject target) {
         final ArrayList<Action> actions = new ArrayList<Action>();
         final List<JobConfigHistoryProjectAction> historyJobActions = target.getActions(JobConfigHistoryProjectAction.class);
-        LOG.fine(target + " already had " + historyJobActions);
+        LOG.log(Level.FINE, "{0} already had {1}", new Object[] {target, historyJobActions});
         final JobConfigHistoryProjectAction newAction = new JobConfigHistoryProjectAction(target);
         actions.add(newAction);
-        LOG.fine(this + " adds " + newAction + " for " + target);
+        LOG.log(Level.FINE, "{0} adds {1} for {2}", new Object[] {this, newAction, target});
         return actions;
     }
 }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryJobListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryJobListener.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jobConfigHistory;
 
+import static java.util.logging.Level.*;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.Item;
@@ -28,13 +29,13 @@ public final class JobConfigHistoryJobListener extends ItemListener {
     /** {@inheritDoc} */
     @Override
     public void onCreated(Item item) {
-        LOG.finest("In onCreated for " + item);
+        LOG.log(FINEST, "In onCreated for {0}", item);
         if (item instanceof AbstractItem) {
             ConfigHistoryListenerHelper.CREATED.createNewHistoryEntry(((AbstractItem) item).getConfigFile());
         } else {
             LOG.finest("onCreated: not an AbstractItem, skipping history save");
         }
-        LOG.finest("onCreated for " + item + " done.");
+        LOG.log(FINEST, "onCreated for {0} done.", item);
         //        new Exception("STACKTRACE for double invocation").printStackTrace();
     }
 
@@ -47,7 +48,7 @@ public final class JobConfigHistoryJobListener extends ItemListener {
     @Override
     public void onRenamed(Item item, String oldName, String newName) {
         final String onRenameDesc = " old name: " + oldName + ", new name: " + newName;
-        LOG.finest("In onRenamed for " + item + onRenameDesc);
+        LOG.log(FINEST, "In onRenamed for {0}{1}", new Object[] {item, onRenameDesc});
         if (item instanceof AbstractItem) {
             final JobConfigHistory plugin = Hudson.getInstance().getPlugin(JobConfigHistory.class);
 
@@ -63,7 +64,7 @@ public final class JobConfigHistoryJobListener extends ItemListener {
                     try {
                         fp.copyRecursiveTo(new FilePath(currentHistoryDir));
                         fp.deleteRecursive();
-                        LOG.finest("completed move of old history files on rename." + onRenameDesc);
+                        LOG.log(FINEST, "completed move of old history files on rename.{0}", onRenameDesc);
                     } catch (IOException e) {
                         final String ioExceptionStr = "unable to move old history on rename." + onRenameDesc;
                         LOG.log(Level.SEVERE, ioExceptionStr, e);
@@ -76,14 +77,14 @@ public final class JobConfigHistoryJobListener extends ItemListener {
             // Must do this after moving old history, in case a CHANGED was fired during the same second under the old name.
             ConfigHistoryListenerHelper.RENAMED.createNewHistoryEntry(((AbstractItem) item).getConfigFile());
         }
-        LOG.finest("Completed onRename for" + item + " done.");
+        LOG.log(FINEST, "Completed onRename for {0} done.", item);
 //        new Exception("STACKTRACE for double invocation").printStackTrace();
     }
 
     /** {@inheritDoc} */
     @Override
     public void onDeleted(Item item) {
-        LOG.finest("In onDeleted for " + item);
+        LOG.log(FINEST, "In onDeleted for {0}", item);
         if (item instanceof AbstractItem) {
             final JobConfigHistory plugin = Hudson.getInstance().getPlugin(JobConfigHistory.class);
             
@@ -99,6 +100,6 @@ public final class JobConfigHistoryJobListener extends ItemListener {
                 LOG.warning("unable to rename deleted history dir to: " + deletedHistoryDir);
             }
         }
-        LOG.finest("onDeleted for " + item + " done.");
+        LOG.log(FINEST, "onDeleted for {0} done.", item);
     }
 }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
@@ -1,5 +1,7 @@
 package hudson.plugins.jobConfigHistory;
 
+import static java.util.logging.Level.*;
+
 import java.io.File;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -7,6 +9,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.apache.commons.lang.StringUtils;
@@ -52,7 +55,7 @@ public class JobConfigHistoryPurger extends PeriodicWork {
             }
         }
         if (maxAge > 0) {
-            LOG.fine("checking for history files to purge (max age of " + maxAge + " days allowed)");
+            LOG.log(FINE, "checking for history files to purge (max age of {0} days allowed)", maxAge);
             this.maxAge = maxAge;
             purgeHistoryByAge();
         }
@@ -80,7 +83,7 @@ public class JobConfigHistoryPurger extends PeriodicWork {
                     for (File historyDir : historyDirs) {
                         //historyDir: e.g. 2013-01-18_17-33-51
                         if (isTooOld(historyDir)) {
-                            LOG.finest("Should delete: " + historyDir);
+                            LOG.log(FINEST, "Should delete: {0}", historyDir);
                             deleteDirectory(historyDir);
                         } else {
                             break;

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -1,5 +1,7 @@
 package hudson.plugins.jobConfigHistory;
 
+import static java.util.logging.Level.*;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -112,7 +114,7 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction imple
         }
 
         if (!historyRootDir.isDirectory()) {
-            LOG.fine(historyRootDir + " is not a directory, assuming that no history exists yet.");
+            LOG.log(FINE, "{0} is not a directory, assuming that no history exists yet.", historyRootDir);
         } else {
             final File[] itemDirs = historyRootDir.listFiles();
             for (final File itemDir : itemDirs) {
@@ -149,7 +151,7 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction imple
         }
 
         if (!historyRootDir.isDirectory()) {
-            LOG.fine(historyRootDir + " is not a directory, assuming that no history exists yet.");
+            LOG.log(FINE, "{0} is not a directory, assuming that no history exists yet.", historyRootDir);
         } else {
             addConfigs(configs, type, historyRootDir, "");
         }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistorySaveableListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistorySaveableListener.java
@@ -1,5 +1,6 @@
 package hudson.plugins.jobConfigHistory;
 
+import static java.util.logging.Level.*;
 import hudson.Extension;
 import hudson.XmlFile;
 import hudson.model.Hudson;
@@ -24,11 +25,11 @@ public final class JobConfigHistorySaveableListener extends SaveableListener {
     public void onChange(final Saveable o, final XmlFile file) {
         final JobConfigHistory plugin = Hudson.getInstance().getPlugin(JobConfigHistory.class);
 
-        LOG.finest("In onChange for " + o);
+        LOG.log(FINEST, "In onChange for {0}", o);
         if (plugin.isSaveable(o, file)) {
             ConfigHistoryListenerHelper.CHANGED.createNewHistoryEntry(file);
         }
-        LOG.finest("onChange for " + o + " done.");
+        LOG.log(FINEST, "onChange for {0} done.", o);
         //        new Exception("STACKTRACE for double invocation").printStackTrace();
     }
 }


### PR DESCRIPTION
due to unnecessary usage of Fingerprint.toString(). Since fingerprints are created in parallel in newer versions, this leads to complete blocking of all CPUs after the completion of large (=many modules) Maven jobs

This Pull Request guards all Log statements, preventing unnecessary toString calls.

see https://issues.jenkins-ci.org/browse/JENKINS-18473
