### PR TITLE
[FIXED JENKINS-22796] Added REST API support for root and job actions.

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -3,6 +3,7 @@ package hudson.plugins.jobConfigHistory;
 import hudson.XmlFile;
 import hudson.maven.MavenModule;
 import hudson.model.AbstractItem;
+import hudson.model.Api;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.plugins.jobConfigHistory.SideBySideView.Line;
@@ -24,10 +25,13 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.ExportedBean;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  * @author Stefan Brausch
  */
+@ExportedBean
 public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 
     /** The project. */
@@ -78,6 +82,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @throws IOException
      *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
      */
+    @Exported
     public final List<ConfigInfo> getJobConfigs() throws IOException {
         checkConfigurePermission();
         final ArrayList<ConfigInfo> configs = new ArrayList<ConfigInfo>();
@@ -330,4 +335,7 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
         return PluginUtils.getHistoryDao();
     }
 
+    public Api getApi() {
+        return new Api(this);
+    }
 }

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -2,6 +2,7 @@ package hudson.plugins.jobConfigHistory;
 
 import hudson.Extension;
 import hudson.XmlFile;
+import hudson.model.Api;
 import hudson.model.Item;
 import hudson.model.RootAction;
 import hudson.model.TopLevelItem;
@@ -24,12 +25,15 @@ import java.util.logging.Logger;
 import javax.servlet.ServletException;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.export.ExportedBean;
+import org.kohsuke.stapler.export.Exported;
 
 /**
  *
  * @author Stefan Brausch, mfriedenhagen
  */
 
+@ExportedBean
 @Extension
 public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
         implements RootAction {
@@ -79,6 +83,7 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
      * @throws IOException
      *             if one of the history entries might not be read.
      */
+    @Exported
     public final List<ConfigInfo> getConfigs() throws IOException {
         final String filter = getRequestParameter("filter");
         List<ConfigInfo> configs = null;
@@ -446,5 +451,9 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
      */
     OverviewHistoryDao getOverviewHistoryDao() {
         return PluginUtils.getHistoryDao();
+    }
+
+    public Api getApi() {
+        return new Api(this);
     }
 }


### PR DESCRIPTION
Added REST API support for the root and job actions of jobConfigHistory by exporting the getConfigs/getJobConfigs methods of their respective classes and adding a getApi() method call.
