### PR TITLE
REST API support fixes

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction.java
@@ -22,6 +22,8 @@ import java.util.SortedMap;
 import java.util.Map.Entry;
 import jenkins.model.Jenkins;
 
+import org.acegisecurity.AuthenticationException;
+
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -32,7 +34,7 @@ import org.kohsuke.stapler.export.Exported;
  *
  * @author Lucie Votypkova
  */
-@ExportedBean
+@ExportedBean(defaultVisibility = -1)
 public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
     
     /**
@@ -105,7 +107,6 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
      * @throws IOException
      *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
      */
-    @Exported
     public final List<ConfigInfo> getSlaveConfigs() throws IOException {
         checkConfigurePermission();
         final ArrayList<ConfigInfo> configs = new ArrayList<ConfigInfo>();
@@ -132,6 +133,24 @@ public class ComputerConfigHistoryAction extends JobConfigHistoryBaseAction {
         return configs;
     }
     
+    /**
+     * Returns the configuration history entries for one {@link Slave} for the REST API.
+     *
+     * @return history list for one {@link Slave}, or an empty list if not authorized.
+     * @throws IOException
+     *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
+     */
+    @Exported(name = "jobConfigHistory", visibility = 1)
+    public final List<ConfigInfo> getSlaveConfigsREST() throws IOException {
+      List<ConfigInfo> configs = null;
+      try {
+          configs = getSlaveConfigs();
+      } catch (org.acegisecurity.AccessDeniedException e) {
+          configs = new ArrayList<ConfigInfo>();
+      }
+      return configs;
+    }
+
     /**
      * Used in the Difference jelly only. Returns one of the two timestamps that
      * have been passed to the Difference page as parameter. timestampNumber

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction.java
@@ -23,6 +23,8 @@ import java.util.SortedMap;
 import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
+import org.acegisecurity.AuthenticationException;
+
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.export.ExportedBean;
@@ -31,7 +33,7 @@ import org.kohsuke.stapler.export.Exported;
 /**
  * @author Stefan Brausch
  */
-@ExportedBean
+@ExportedBean(defaultVisibility = -1)
 public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
 
     /** The project. */
@@ -82,7 +84,6 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
      * @throws IOException
      *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
      */
-    @Exported
     public final List<ConfigInfo> getJobConfigs() throws IOException {
         checkConfigurePermission();
         final ArrayList<ConfigInfo> configs = new ArrayList<ConfigInfo>();
@@ -113,6 +114,24 @@ public class JobConfigHistoryProjectAction extends JobConfigHistoryBaseAction {
             }
         }
         Collections.sort(configs, ParsedDateComparator.DESCENDING);
+        return configs;
+    }
+
+    /**
+     * Returns the configuration history entries for one {@link AbstractItem} for the REST API.
+     *
+     * @return history list for one {@link AbstractItem}, or an empty list if not authorized.
+     * @throws IOException
+     *             if {@link JobConfigHistoryConsts#HISTORY_FILE} might not be read or the path might not be urlencoded.
+     */
+    @Exported(name = "jobConfigHistory", visibility = 1)
+    public final List<ConfigInfo> getJobConfigsREST() throws IOException {
+        List<ConfigInfo> configs = null;
+        try {
+            configs = getJobConfigs();
+        } catch (org.acegisecurity.AccessDeniedException e) {
+            configs = new ArrayList<ConfigInfo>();
+        }
         return configs;
     }
 

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction.java
@@ -33,7 +33,7 @@ import org.kohsuke.stapler.export.Exported;
  * @author Stefan Brausch, mfriedenhagen
  */
 
-@ExportedBean
+@ExportedBean(defaultVisibility = -1)
 @Extension
 public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
         implements RootAction {
@@ -83,7 +83,7 @@ public class JobConfigHistoryRootAction extends JobConfigHistoryBaseAction
      * @throws IOException
      *             if one of the history entries might not be read.
      */
-    @Exported
+    @Exported(visibility = 1)
     public final List<ConfigInfo> getConfigs() throws IOException {
         final String filter = getRequestParameter("filter");
         List<ConfigInfo> configs = null;


### PR DESCRIPTION
Added REST API support for slaves, fixed a problem when making REST requests anonymously, and adjusted the visibility settings so at the default depth, you don't get job configuration history (which might cause problems if a history is particularly long).
