### PR TITLE
MavenModuleSet should always be saved

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -3,6 +3,7 @@ package hudson.plugins.jobConfigHistory;
 import hudson.Plugin;
 import hudson.XmlFile;
 import hudson.maven.MavenModule;
+import hudson.maven.MavenModuleSet;
 import hudson.model.AbstractProject;
 import hudson.model.Descriptor.FormException;
 import hudson.model.Hudson;
@@ -353,6 +354,9 @@ public class JobConfigHistory extends Plugin {
         } else if (xmlFile.getFile().getParentFile().equals(getJenkinsHome())) {
             saveable = checkRegex(xmlFile);
         } else if (saveItemGroupConfiguration && group) {
+            saveable = true;
+        }
+        if (item instanceof MavenModuleSet) {
             saveable = true;
         }
         if (item instanceof MavenModule && !saveModuleConfiguration) {

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryIT.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import hudson.maven.MavenModuleSet;
 
 import org.xml.sax.SAXException;
 
@@ -78,7 +79,7 @@ public class JobConfigHistoryIT extends AbstractHudsonTestCaseDeletingInstanceDi
         assertFalse("Verify false when testing if a file outside of HUDSON_ROOT is saveable.", jch.isSaveable(null, new XmlFile(new File("/tmp/config.xml"))));
     }
 
-    public void testJobConfigHistoryDefaults() {
+    public void testJobConfigHistoryDefaults() throws IOException {
         final JobConfigHistory jch = hudson.getPlugin(JobConfigHistory.class);
 
         assertNull("Verify number of history entries to keep default setting.", jch.getMaxHistoryEntries());
@@ -89,6 +90,9 @@ public class JobConfigHistoryIT extends AbstractHudsonTestCaseDeletingInstanceDi
 
         final XmlFile hudsonConfig = new XmlFile(new File(hudson.getRootDir(), "config.xml"));
         assertTrue("Verify a system level configuration is saveable.", jch.isSaveable(hudson, hudsonConfig));
+        // This would more naturally belong in JobConfigHistoryTest.testIsSaveable but Mockito chokes on MavenModuleSet.<clinit>:
+        MavenModuleSet mms = createMavenProject();
+        assertTrue("MavenModuleSet should be saved", jch.isSaveable(mms, mms.getConfigFile()));
 
         assertTrue("Verify system configuration history location", getHistoryDir(hudsonConfig).getParentFile().equals(jch.getConfiguredHistoryRootDir()));
         testCreateRenameDeleteProject(jch);


### PR DESCRIPTION
Corrects a regression in 2.6 introduced by my own #26 but for which there had been no test.

Generally, I would suggest you just delete the `saveItemGroupConfiguration` option and always save folder configurations; I cannot think of any reason why you would want this to be off, much less off _by default_. I would also suggest you delete the `saveModuleConfiguration` option and not save configuration of any `Item` which is not a `TopLevelItem`; or at least not save this by default. (By checking for `TopLevelItem` rather than explicitly for `MavenModule` you should be able to remove the dependency on `maven-plugin` as requested in [JENKINS-19141](https://issues.jenkins-ci.org/browse/JENKINS-19141), making the code more generic and so properly handling matrix configurations, Literate branches and environments, ad nauseam.) If you agree with this proposal I may have time to draft it as a PR.
