### PR TITLE
NPE on ComputerHistoryListener.onConfigurationChange

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerHistoryListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerHistoryListener.java
@@ -28,6 +28,12 @@ public class ComputerHistoryListener extends ComputerListener {
     
     @Override
     public void onConfigurationChange() {
+    	// Ensure nodes is configured as getNodes() may return null
+    	// during class initialization. NodeList will surely be defined
+    	// on the first run of this method.
+    	if (nodes == null) {
+    		nodes = Jenkins.getInstance().getNodes();
+    	}
         if (nodes.size() < Jenkins.getInstance().getNodes().size()) {
             onAdd();
             nodes = Jenkins.getInstance().getNodes();


### PR DESCRIPTION
Fix proposal for NPE in ComputerHistoryListener.onConfigurationChange method. Our jenkins faced some restart issue with the following stacktrace. Since initializing the list with getNodes might be unsafe as Jenkins is initializing. Better to ensure the nodes list is defined on the first run (if nodes is null, then get the initial list of nodes).

hudson.util.HudsonFailedToLoad: java.lang.NullPointerException
  at hudson.WebAppMain$3.run(WebAppMain.java:234)
Caused by: java.lang.NullPointerException
  at
hudson.plugins.jobConfigHistory.ComputerHistoryListener.onConfigurationChange(ComputerHistoryListener.java:29)
  at
hudson.model.AbstractCIBase.updateComputerList(AbstractCIBase.java:195)
  at jenkins.model.Jenkins.updateComputerList(Jenkins.java:1220)
  at jenkins.model.Jenkins.<init>(Jenkins.java:852)
  at hudson.model.Hudson.<init>(Hudson.java:82)
  at hudson.model.Hudson.<init>(Hudson.java:78)
  at hudson.WebAppMain$3.run(WebAppMain.java:222)
