### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
                 <artifactId>commons-net</artifactId>
                 <version>3.6</version>
             </dependency>
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.4.01</version>
+             </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -148,6 +153,12 @@
             <artifactId>maven-plugin</artifactId>
             <version>3.0</version>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+            <version>2.7.2</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Added dependency to fix runtime error:

java.util.ServiceConfigurationError: javax.xml.transform.TransformerFactory: Provider org.apache.xalan.processor.TransformerFactoryImpl not a subtype
       at java.util.ServiceLoader.fail(ServiceLoader.java:239)
       at java.util.ServiceLoader.access$300(ServiceLoader.java:185)
       at java.util.ServiceLoader$LazyIterator.nextService(ServiceLoader.java:376)
       at java.util.ServiceLoader$LazyIterator.next(ServiceLoader.java:404)
       at java.util.ServiceLoader$1.next(ServiceLoader.java:480)
       at javax.xml.transform.FactoryFinder$1.run(FactoryFinder.java:280)
       at java.security.AccessController.doPrivileged(Native Method)
       at javax.xml.transform.FactoryFinder.findServiceProvider(FactoryFinder.java:275)
Caused: java.lang.RuntimeException: Provider for class javax.xml.transform.TransformerFactory cannot be created
       at javax.xml.transform.FactoryFinder.findServiceProvider(FactoryFinder.java:294)
       at javax.xml.transform.FactoryFinder.find(FactoryFinder.java:251)
       at javax.xml.transform.TransformerFactory.newInstance(TransformerFactory.java:106)
       at hudson.plugins.jobConfigHistory.JobConfigHistoryBaseAction.<init>(JobConfigHistoryBaseAction.)