### PR TITLE
Switch to a more incluse terminology, where applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,7 +105,7 @@
 
 ## Version 2.11 (April 17 2015)
 * Avoid calling User.current() during Jenkins initialization (Thanks to Thomas de Grenier de Latour)
-* Avoid tracking changes for cloud slave as well (Thanks to Ryan Campbel)
+* Avoid tracking changes for cloud agents as well (Thanks to Ryan Campbel)
 
 ## Version 2.10 (November 12 2014)
 * Fix proposal for NPE in ComputerHistoryListener.onConfigurationChange method (Thanks to William Bernardet)
@@ -129,7 +129,7 @@
 ## Version 2.6 (Apr 14 2014)
 * Diff view: easily review changes sequentially (Next/Previous links) (JENKINS-21411)
 * Show Config Versions in Diff View (JENKINS-21406)
-* Add config history for slaves too (Thanks to Lucie Votypkova)
+* Add config history for agents too (Thanks to Lucie Votypkova)
 * Folder integration (JENKINS-20990) (Thanks to Jesse Glick)
 
 ## Version 2.5 (Oct 31 2013)

--- a/src/main/java/hudson/plugins/jobConfigHistory/ComputerHistoryListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/ComputerHistoryListener.java
@@ -71,7 +71,7 @@ public class ComputerHistoryListener extends ComputerListener {
     }
 
     /**
-     * If a new slave get added.
+     * If a new agent gets added.
      */
     private void onAdd() {
         Jenkins jenkins = Jenkins.get();
@@ -93,7 +93,7 @@ public class ComputerHistoryListener extends ComputerListener {
     }
 
     /**
-     * If a slave get removed.
+     * If an agent gets removed.
      */
     private void onRemove() {
         Jenkins jenkins = Jenkins.get();
@@ -107,7 +107,7 @@ public class ComputerHistoryListener extends ComputerListener {
     }
 
     /**
-     * If a slave configuration get changed.
+     * If an agent configuration get changed.
      */
     private void onChange() {
         Jenkins jenkins = Jenkins.get();
@@ -122,7 +122,7 @@ public class ComputerHistoryListener extends ComputerListener {
     }
 
     /**
-     * If a slave get renamed.
+     * If an agent gets renamed.
      */
     private void onRename() {
         Node originalNode = null;
@@ -179,19 +179,19 @@ public class ComputerHistoryListener extends ComputerListener {
 
         @Override
         public void createNewNode(Node node) {
-            LOG.log(Level.FINEST, "onCreated: not an Slave {0}, skipping.",
+            LOG.log(Level.FINEST, "onCreated: not an agent {0}, skipping.",
                     node);
         }
 
         @Override
         public void renameNode(Node node, String oldName, String newName) {
-            LOG.log(Level.FINEST, "onRenamed: not an Slave {0}, skipping.",
+            LOG.log(Level.FINEST, "onRenamed: not an agent {0}, skipping.",
                     node);
         }
 
         @Override
         public void deleteNode(Node node) {
-            LOG.log(Level.FINEST, "onDeleted: not an Slave {0}, skipping.",
+            LOG.log(Level.FINEST, "onDeleted: not an agent {0}, skipping.",
                     node);
         }
 

--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -1134,7 +1134,7 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
         final String onRenameDesc = " old name: " + oldName + ", new name: "
                 + newName;
         if (historyRootDir != null) {
-            // final File configFile = aItem.getConfigFile().getSlaveFile();
+            // final File configFile = aItem.getConfigFile().getAgentFile();
             final File currentHistoryDir = getHistoryDirForNode(node);
             final File historyParentDir = currentHistoryDir.getParentFile();
             final File oldHistoryDir = new File(historyParentDir, oldName);

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryStrategy.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryStrategy.java
@@ -30,7 +30,7 @@ import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
 /**
- * Master class for adding new backends to the history plugin.
+ * Controller class for adding new backends to the history plugin.
  *
  * @author Brandon Koepke
  */

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/index.jelly
@@ -4,7 +4,7 @@
 
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css"></link>
 
-    <st:include it="${it.slave.toComputer()}" page="sidepanel.jelly" />
+    <st:include it="${it.agent.toComputer()}" page="sidepanel.jelly" />
     <l:main-panel>
       <h1>${%Agent Configuration History}</h1>
       <div>
@@ -18,10 +18,10 @@
             document.getElementById('tooltip' + nr).style.visibility = 'hidden';
           }
         </script>
-        <j:set var="configs" value="${it.getSlaveConfigs()}" />
+        <j:set var="configs" value="${it.getAgentConfigs()}" />
         <j:choose>
           <j:when test="${configs.size() == 0}">
-            ${%No slave configuration history available}
+            ${%No agent configuration history available}
           </j:when>
           <j:otherwise>
             <br/>
@@ -39,7 +39,7 @@
                 <table class="jch" style="width:100%">
                   <thead>
                     <caption class="caption">
-                      ${it.getSlave().getNodeName()}
+                      ${it.getAgent().getNodeName()}
                     </caption>
                   </thead>
                 </table>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/restoreQuestion.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/restoreQuestion.jelly
@@ -4,7 +4,7 @@
 
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css"></link>
 
-    <st:include it="${it.slave.toComputer()}" page="sidepanel.jelly" />
+    <st:include it="${it.agent.toComputer()}" page="sidepanel.jelly" />
     <l:main-panel>
       <j:set var="timestamp" value="${request.getParameter('timestamp')}" />
 

--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
@@ -50,7 +50,7 @@
           <j:when test="${!it.hasConfigurePermission()}">
             ${%No permission to view config history}
           </j:when>
-          <j:when test="${it.getSlaveConfigs().size() == 0}">
+          <j:when test="${it.getAgentConfigs().size() == 0}">
             ${%No agent configuration history available}
           </j:when>
           <j:otherwise>
@@ -91,7 +91,7 @@
               <table style="width:100%;" class="center jch">
                 <thead>
                   <caption class="caption" style="text-align:center">
-                    ${it.getSlave().getNodeName()}
+                    ${it.getAgent().getNodeName()}
                   </caption>
                   <tr>
                     <th colspan="2" class="subcaption">
@@ -113,7 +113,7 @@
                       <div style="float:bottom" class="singleLineView description">
                         <div>
                           <b>${%Date}:</b>
-                          <a class="url-button" href="${rootURL}/${it.getProject().getUrl()}/computer/${it.getSlave().getNodeName()}/jobConfigHistory/configOutput?type=xml&amp;name=config&amp;timestamp=${it.getTimestamp(1)}">
+                          <a class="url-button" href="${rootURL}/${it.getProject().getUrl()}/computer/${it.getAgent().getNodeName()}/jobConfigHistory/configOutput?type=xml&amp;name=config&amp;timestamp=${it.getTimestamp(1)}">
                             ${it.getTimestamp(1)}
                           </a>
                         </div>
@@ -143,7 +143,7 @@
                       <div style="float:bottom" class="singleLineView description">
                         <div>
                           <b>${%Date}:</b>
-                          <a class="url-button" href="${rootURL}/${it.getProject().getUrl()}/computer/${it.getSlave().getNodeName()}/jobConfigHistory/configOutput?type=xml&amp;name=config&amp;timestamp=${it.getTimestamp(2)}">
+                          <a class="url-button" href="${rootURL}/${it.getProject().getUrl()}/computer/${it.getAgent().getNodeName()}/jobConfigHistory/configOutput?type=xml&amp;name=config&amp;timestamp=${it.getTimestamp(2)}">
                             ${it.getTimestamp(2)}
                           </a>
                         </div>

--- a/src/test/java/hudson/plugins/jobConfigHistory/ComputerHistoryListenerIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/ComputerHistoryListenerIT.java
@@ -23,15 +23,15 @@ public class ComputerHistoryListenerIT {
 
     @Test
     public void testOnConfigurationChange_create() throws Exception {
-        Slave slave1 = rule.createOnlineSlave();
+        Slave agentOne = rule.createOnlineSlave();
         JobConfigHistoryStrategy dao = PluginUtils.getHistoryDao();
-        SortedMap<String, HistoryDescr> revisions = dao.getRevisions(slave1);
+        SortedMap<String, HistoryDescr> revisions = dao.getRevisions(agentOne);
         assertNotNull("Revisions should exists.", revisions);
         assertFalse("Revisions should not be empty.", revisions.isEmpty());
         assertEquals("Revisions should contains 1 revision.", 1,
                 revisions.size());
         String firstKey = revisions.firstKey();
-        HistoryDescr descr = dao.getRevisions(slave1).get(firstKey);
+        HistoryDescr descr = dao.getRevisions(agentOne).get(firstKey);
         assertEquals("Revisions should have status created.",
                 Messages.ConfigHistoryListenerHelper_CREATED(),
                 descr.getOperation());
@@ -39,84 +39,84 @@ public class ComputerHistoryListenerIT {
 
     @Test
     public void testOnConfigurationChange_rename() throws Exception {
-        Slave slave1 = rule.createOnlineSlave();
-        Slave slave2 = rule.createOnlineSlave();
-        Slave slave3 = rule.createOnlineSlave();
-        HtmlForm form = rule.createWebClient().getPage(slave2, "configure")
+        Slave agentOne = rule.createOnlineSlave();
+        Slave agentTwo = rule.createOnlineSlave();
+        Slave agentThree = rule.createOnlineSlave();
+        HtmlForm form = rule.createWebClient().getPage(agentTwo, "configure")
                 .getFormByName("config");
         HtmlInput element = form.getInputByName("_.name");
-        element.setValueAttribute("newSlaveName");
+        element.setValueAttribute("newAgentName");
         rule.submit(form);
-        slave2 = (Slave) rule.jenkins.getNode("newSlaveName");
+        agentTwo = (Slave) rule.jenkins.getNode("newAgentName");
         JobConfigHistoryStrategy dao = PluginUtils.getHistoryDao();
         assertEquals(
-                "Revisions of " + slave1.getNodeName()
+                "Revisions of " + agentOne.getNodeName()
                         + " should contains 1 revision.",
-                1, dao.getRevisions(slave1).size());
+                1, dao.getRevisions(agentOne).size());
         assertEquals(
-                "Revisions of " + slave2.getNodeName()
+                "Revisions of " + agentTwo.getNodeName()
                         + " should contains 2 revision.",
-                2, dao.getRevisions(slave2).size());
+                2, dao.getRevisions(agentTwo).size());
         assertEquals(
-                "Revisions of " + slave3.getNodeName()
+                "Revisions of " + agentThree.getNodeName()
                         + " should contains 1 revision.",
-                1, dao.getRevisions(slave3).size());
-        String key = dao.getRevisions(slave2).lastKey();
+                1, dao.getRevisions(agentThree).size());
+        String key = dao.getRevisions(agentTwo).lastKey();
         assertEquals(
-                "The last revision of slave " + slave2.getNodeName()
+                "The last revision of agent " + agentTwo.getNodeName()
                         + " should have state renamed.",
                 Messages.ConfigHistoryListenerHelper_RENAMED(),
-                dao.getRevisions(slave2).get(key).getOperation());
+                dao.getRevisions(agentTwo).get(key).getOperation());
     }
 
     @Test
     public void testOnConfigurationChange_delete() throws Exception {
-        Slave slave1 = rule.createOnlineSlave();
-        Slave slave2 = rule.createOnlineSlave();
-        Slave slave3 = rule.createOnlineSlave();
-        rule.jenkins.removeNode(slave2);
+        Slave agentOne = rule.createOnlineSlave();
+        Slave agentTwo = rule.createOnlineSlave();
+        Slave agentThree = rule.createOnlineSlave();
+        rule.jenkins.removeNode(agentTwo);
         JobConfigHistoryStrategy dao = PluginUtils.getHistoryDao();
         assertEquals(
-                "Revisions of " + slave1.getNodeName()
+                "Revisions of " + agentOne.getNodeName()
                         + " should contains 1 revision.",
-                1, dao.getRevisions(slave1).size());
-        assertEquals(slave2.getNodeName() + " should have any revision.", 0,
-                dao.getRevisions(slave2).size());
+                1, dao.getRevisions(agentOne).size());
+        assertEquals(agentTwo.getNodeName() + " should have any revision.", 0,
+                dao.getRevisions(agentTwo).size());
         assertEquals(
-                "Revisions of " + slave3.getNodeName()
+                "Revisions of " + agentThree.getNodeName()
                         + " should contains 1 revision.",
-                1, dao.getRevisions(slave3).size());
+                1, dao.getRevisions(agentThree).size());
     }
 
     @Test
     public void testOnConfigurationChange_change() throws Exception {
-        Slave slave1 = rule.createOnlineSlave();
-        Slave slave2 = rule.createOnlineSlave();
-        Slave slave3 = rule.createOnlineSlave();
-        HtmlForm form = rule.createWebClient().getPage(slave2, "configure")
+        Slave agentOne = rule.createOnlineSlave();
+        Slave agentTwo = rule.createOnlineSlave();
+        Slave agentThree = rule.createOnlineSlave();
+        HtmlForm form = rule.createWebClient().getPage(agentTwo, "configure")
                 .getFormByName("config");
         HtmlInput element = form.getInputByName("_.nodeDescription");
         element.setValueAttribute("Node description");
         rule.submit(form);
         JobConfigHistoryStrategy dao = PluginUtils.getHistoryDao();
         assertEquals(
-                "Revisions of " + slave1.getNodeName()
+                "Revisions of " + agentOne.getNodeName()
                         + " should contains 1 revision.",
-                1, dao.getRevisions(slave1).size());
+                1, dao.getRevisions(agentOne).size());
         assertEquals(
-                "Revisions of " + slave2.getNodeName()
+                "Revisions of " + agentTwo.getNodeName()
                         + " should contains 2 revision.",
-                2, dao.getRevisions(slave2).size());
+                2, dao.getRevisions(agentTwo).size());
         assertEquals(
-                "Revisions of " + slave3.getNodeName()
+                "Revisions of " + agentThree.getNodeName()
                         + " should contains 1 revision.",
-                1, dao.getRevisions(slave3).size());
-        String key = dao.getRevisions(slave2).lastKey();
+                1, dao.getRevisions(agentThree).size());
+        String key = dao.getRevisions(agentTwo).lastKey();
         assertEquals(
-                "The last revision of slave " + slave2.getNodeName()
+                "The last revision of agent " + agentTwo.getNodeName()
                         + " should have state changed.",
                 Messages.ConfigHistoryListenerHelper_CHANGED(),
-                dao.getRevisions(slave2).get(key).getOperation());
+                dao.getRevisions(agentTwo).get(key).getOperation());
     }
 
 }

--- a/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
@@ -746,11 +746,11 @@ public class FileHistoryDaoTest {
 
     @Test
     public void testCreateNewNode() throws Exception {
-        when(mockedNode.getNodeName()).thenReturn("slave1");
+        when(mockedNode.getNodeName()).thenReturn("agentOne");
         sutWithUserAndNoDuplicateHistory.createNewNode(mockedNode);
         File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
-        File revisions = new File(file, "slave1");
-        assertEquals("Slave1 should have only one save history.", 1,
+        File revisions = new File(file, "agentOne");
+        assertEquals("agentOne should have only one save history.", 1,
                 revisions.list().length);
         File config = new File(revisions.listFiles()[0], "config.xml");
         assertTrue("File config.xml should be saved.", config.exists());
@@ -765,9 +765,9 @@ public class FileHistoryDaoTest {
      * {@link #testRenameNode()}.
      */
     private void printTestData(Callable<Void> func) throws Exception {
-        when(mockedNode.getNodeName()).thenReturn("slave1");
+        when(mockedNode.getNodeName()).thenReturn("agentOne");
         File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
-        File revisions = new File(file, "slave1");
+        File revisions = new File(file, "agentOne");
         File revision = new File(revisions, "2014-01-20_10-12-34");
         revision.mkdirs();
         File config = new File(revision, "config.xml");
@@ -808,7 +808,7 @@ public class FileHistoryDaoTest {
 
     @Test
     public void testGetRevisions() throws Exception {
-        when(mockedNode.getNodeName()).thenReturn("slave1");
+        when(mockedNode.getNodeName()).thenReturn("agentOne");
         createNodeRevisionManually("2014-01-18_10-12-34", getRandomConfigXml(), getHistoryXmlFromTimestamp("2014-01-18_10-12-34"));
         createNodeRevisionManually("2014-01-19_10-12-34", getRandomConfigXml(), getHistoryXmlFromTimestamp("2014-01-19_10-12-34"));
         createNodeRevisionManually("2014-01-20_10-12-34", getRandomConfigXml(), getHistoryXmlFromTimestamp("2014-01-20_10-12-34"));
@@ -828,7 +828,7 @@ public class FileHistoryDaoTest {
 
     private File createNodeRevisionManually(String timestamp, String configXmlContent, String historyXmlContent) throws IOException {
         File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
-        File revisions = new File(file, "slave1");
+        File revisions = new File(file, "agentOne");
         File revision = new File(revisions, timestamp);
         revision.mkdirs();
         FileUtils.writeStringToFile(
@@ -867,7 +867,7 @@ public class FileHistoryDaoTest {
     private File createNodeRevision(String timestamp, Node mockedNode)
             throws Exception {
         File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
-        File revisions = new File(file, "slave1");
+        File revisions = new File(file, "agentOne");
         File revision = new File(revisions, timestamp);
         revision.mkdirs();
         Jenkins.XSTREAM2.toXMLUTF8(mockedNode,
@@ -881,9 +881,9 @@ public class FileHistoryDaoTest {
 
     @Test
     public void testSaveNode() {
-        when(mockedNode.getNodeName()).thenReturn("slave1");
+        when(mockedNode.getNodeName()).thenReturn("agentOne");
         File file = sutWithUserAndNoDuplicateHistory.getNodeHistoryRootDir();
-        File revisions = new File(file, "slave1");
+        File revisions = new File(file, "agentOne");
         sutWithUserAndNoDuplicateHistory.saveNode(mockedNode);
         assertEquals("New revision should be saved.", 1,
                 revisions.list().length);
@@ -891,7 +891,7 @@ public class FileHistoryDaoTest {
 
     @Test
     public void testGetOldRevision_Node() throws Exception {
-        when(mockedNode.getNodeName()).thenReturn("slave1");
+        when(mockedNode.getNodeName()).thenReturn("agentOne");
         when(mockedNode.getNumExecutors()).thenReturn(1);
         File revision1 = createNodeRevision("2014-01-18_10-12-34", mockedNode);
         when(mockedNode.getNumExecutors()).thenReturn(2);


### PR DESCRIPTION
A more inclusive terminology according to the Epic has been provided. Existing methods have been deprecated in favor of a better naming scheme, where applicable.