### PR TITLE
Improve styling of job history table

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -131,7 +131,8 @@
                           <td style="text-align:center">
                             <j:if test="${it.hasDeleteEntryPermission()}">
                               <j:set var="message" value="${%Do you really want to delete the history entry} "/>
-                              <button type="button" class="jenkins-button jenkins-button--transparent" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
+                              <button type="button" class="jenkins-button jenkins-button--destructive" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
+
                                 <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}"/>
                               </button>
                             </j:if>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -39,23 +39,19 @@
             <br/>
             <div>
               <form method="post" action="diffFiles" name="diffFiles">
-                <table class="jch" style="width:100%">
-                  <thead>
-                    <caption class="caption">
-                      ${it.getProject().getFullName()}
-                    </caption>
-                  </thead>
-                </table>
                 <div>
-                  <table id="confighistory" class="pane sortable jch">
+                  <table id="confighistory" class="jenkins-table sortable jenkins-!-margin-bottom-0">
+                    <caption class="caption">
+                      <h2>${it.getProject().getFullName()}</h2>
+                    </caption>
                     <thead>
                       <tr style="position:sticky; top:26px;">
-                        <th initialSortDir="up" align="left">${%Date}</th>
-                        <th>${%Operation}</th>
+                        <th initialSortDir="up" style="text-align:left">${%Date}</th>
+                        <th style="text-align:left"> ${%Operation}</th>
                         <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
                           <th>${%User}</th>
                         </j:if>
-                        <th class="sortheader" align="left">${%Show File}</th>
+                        <th style="text-align:left">${%Show File}</th>
                         <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
                           <th style="text-align:center">${%Restore old config}</th>
                         </j:if>
@@ -71,44 +67,40 @@
                       <j:forEach var="config" items="${configs}">
                         <j:set var="configNr" value="${configNr + 1}"/>
                         <tr class="alternate" id="table-row-${configNr}">
-                          <td>${config.date}</td>
-                          <td>
+                          <!-- Date -->
+                          <td style="text-align:left">${config.date}</td>
+                          <!-- Operation type -->
+                          <td style="text-align:left">
                             <j:if test="${(config.currentName!=null) and (! config.currentName.isEmpty())}">
                               <span>${config.operation}</span>
-                              <span class="icon-sm" >
-                                <l:icon src="symbol-info plugin-jobConfigHistory" tooltip="${%Old name}: ${config.oldName} => ${%New name}: ${config.currentName}" alt="${%Info}" />
-                              </span>
+                              <l:icon src="symbol-info plugin-jobConfigHistory" class="icon-md" tooltip="${%Old name}: ${config.oldName} => ${%New name}: ${config.currentName}" alt="${%Info}" />
                             </j:if>
                             <j:if test="${(config.currentName==null) || (config.currentName.isEmpty())}">
-                              ${config.operation}
+                              <span>${config.operation}</span>
                             </j:if>
                             <j:if test="${config.changeReasonComment != null and !config.changeReasonComment.equals(&quot;&quot;)}">
-                              <span class="icon-sm">
-                                <l:icon src="symbol-info plugin-jobConfigHistory" title="${%Change Message}: &quot;${config.changeReasonComment}&quot;" />
-                              </span>
+                              <l:icon src="symbol-info plugin-jobConfigHistory" class="icon-md" title="${%Change Message}: &quot;${config.changeReasonComment}&quot;" />
                             </j:if>
                           </td>
+                          <!-- User id -->
                           <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
-                            <td><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                            <td style="text-align:left"><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
                           </j:if>
-                          <td>
+                          <!-- Show config -->
+                          <td style="text-align:left">
                             <j:set var="fileMissing" value="${!config.hasConfig()}"/>
                             <j:if test="${!fileMissing}">
-                              <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}"> ${%View as XML} </a>
-                              <st:nbsp />
-                              <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}">
-                                (${%RAW})
-                              </a>
+                              <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}" class="jenkins-table__link"> ${%View as XML} </a>
+                              <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}" class="jenkins-table__link jenkins-table__badge" >${%RAW}</a>
                             </j:if>
                           </td>
+                          <!-- Restore config -->
                           <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
                             <td style="text-align:center">
                               <j:set var="revisionEqualsCurrent" value="${it.revisionEqualsCurrent(config.getDate())}"/>
                               <j:if test="${!revisionEqualsCurrent and !fileMissing}">
-                                <a href="restoreQuestion?timestamp=${config.getDate()}" style="text-decoration: none">
-                                  <span class="icon-md">
-                                    <l:icon id="restore${configNr}" src="symbol-restore plugin-jobConfigHistory" title="${%Restore}" />
-                                  </span>
+                                <a href="restoreQuestion?timestamp=${config.getDate()}" class="jenkins-table__link">
+                                  <l:icon id="restore${configNr}" src="symbol-restore plugin-jobConfigHistory" class="icon-md" title="${%Restore}"  />
                                 </a>
                                 <j:if test="${configNr == 1 and pageNum == 0}">
                                   <!--The current version is not present in history!-->
@@ -123,24 +115,27 @@
                           <j:if test="${configNr == 2 and fileMissing}">
                             <j:set var="offsetIfFileMissing" value="1"/>
                           </j:if>
+                          <!-- File A -->
                           <td style="text-align:center">
                             <j:if test="${!fileMissing}">
-                              <f:radio name="timestamp1" value="${config.getDate()}" checked="${configNr == (2 + offsetIfFileMissing) ? true:false}" />
+                              <f:radio  name="timestamp1" value="${config.getDate()}" checked="${configNr == (2 + offsetIfFileMissing) ? true:false}" />
                             </j:if>
                           </td>
+                          <!-- File B -->
                           <td style="text-align:center">
                             <j:if test="${!fileMissing}">
                               <f:radio name="timestamp2" value="${config.getDate()}" checked="${configNr == 1 ? true:false}" />
                             </j:if>
                           </td>
+                          <!-- Trash icon -->
+                          <td style="text-align:center">
                           <j:if test="${it.hasDeleteEntryPermission()}">
-                            <td style="text-align:center">
                                 <j:set var="message" value="${%Do you really want to delete the history entry} "/>
-                                <button type="button" class="jch delete-button" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
-                                  <l:icon class="icon-stop icon-sm" alt="${%Delete Revision}"/>
+                              <button class="jenkins-button jenkins-button--transparent" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
+                                <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}"/>
                                 </button>
-                            </td>
                           </j:if>
+                          </td>
                         </tr>
                         <f:invisibleEntry>
                           <f:textbox name="name" value="${config.getJob()}" />

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -17,7 +17,7 @@
           <j:set var="pageNum" value="0"/>
         </j:if>
         <j:if test="${entriesPerPage == null or entriesPerPage.equals(&quot;&quot;)}">
-          <j:set var="entriesPerPage" value="${defaultEntriesPerPage}"/>
+          <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}"/>
         </j:if>
         <j:choose>
           <j:when test="${entriesPerPage.equals(&quot;all&quot;)}">

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -13,6 +13,7 @@
         <j:set var="pageNum" value="${request.getParameter('pageNum')}" />
         <j:set var="entriesPerPage" value="${request.getParameter('entriesPerPage')}" />
         <j:set var="totalEntriesNumber" value="${it.getRevisionAmount()}" />
+        <j:set var="requestUrl" value="${rootURL}${request.getPathInfo().toString()}"/>
         <j:if test="${pageNum == null or pageNum.equals(&quot;&quot;)}">
           <j:set var="pageNum" value="0" />
         </j:if>
@@ -157,10 +158,10 @@
                       <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
                         <j:choose>
                           <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
-                            <a class="jenkins-button jenkins-button--primary" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                            <a class="jenkins-button jenkins-button--primary" href="${requestUrl}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
                           </j:when>
                           <j:otherwise>
-                            <a class="jenkins-button" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                            <a class="jenkins-button" href="${requestUrl}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
                           </j:otherwise>
                         </j:choose>
                       </j:forEach>
@@ -174,7 +175,7 @@
                           <!--"<" for one step back-->
                           <j:choose>
                             <j:when test="${pageNum > 0}">
-                              <a class="jenkins-button" href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                              <a class="jenkins-button" href="${requestUrl}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                 <b>&lt;</b>
                               </a>
                             </j:when>
@@ -193,7 +194,7 @@
                                   ${currentPageNum+1}</a>
                               </j:when>
                               <j:otherwise>
-                                <a class="jenkins-button" href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>
                               </j:otherwise>
                             </j:choose>
@@ -202,7 +203,7 @@
                           <!--">" for one step forward-->
                           <j:choose>
                             <j:when test="${maxPageNum > pageNum}">
-                              <a class="jenkins-button" href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                              <a class="jenkins-button" href="${requestUrl}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                 <b>&gt;</b>
                               </a>
                             </j:when>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -8,7 +8,6 @@
     <l:main-panel>
       <h1>${%Job Configuration History}</h1>
       <div>
-
         <script src="${rootURL}/plugin/jobConfigHistory/deleteRevisionAndTableEntry.js"/>
         <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}"/>
         <j:set var="pageNum" value="${request.getParameter('pageNum')}"/>
@@ -129,12 +128,12 @@
                           </td>
                           <!-- Trash icon -->
                           <td style="text-align:center">
-                          <j:if test="${it.hasDeleteEntryPermission()}">
-                                <j:set var="message" value="${%Do you really want to delete the history entry} "/>
+                            <j:if test="${it.hasDeleteEntryPermission()}">
+                              <j:set var="message" value="${%Do you really want to delete the history entry} "/>
                               <button class="jenkins-button jenkins-button--transparent" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
                                 <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}"/>
-                                </button>
-                          </j:if>
+                              </button>
+                            </j:if>
                           </td>
                         </tr>
                         <f:invisibleEntry>
@@ -146,83 +145,92 @@
                 </div>
                 <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}"/>
                 <div class="jch-footer">
-                  <table class="footer-content-wrapper"><tr><td style="padding:0px;">
-                      <div style="float:left; width:34%">
-                        <table class="jch navigation">
-                          <tr>
-                            <td style="width:150px; font-weight:bold;">${%Entries per page}:</td>
-                            <!--                          <td><div class="menu-url-button current">${entriesPerPage}</div></td>-->
-                            <td><div class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}">10</a>
-                            </div></td>
-                            <td><div class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}">25</a>
-                            </div></td>
-                            <td><div class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}">100</a>
-                            </div></td>
-                            <td><div class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}">250</a>
-                            </div></td>
-                            <td><div class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?entriesPerPage=${&quot;all&quot;}">${%all}</a>
-                            </div></td>
-                          </tr>
-                        </table>
+                  <div style="float:left; width:30%">
+                    <f:bottomButtonBar>
+                      <div class="jenkins-buttons-row">
+                        <h3>"${%Entries per page}:"</h3>
+                        <button class="jenkins-button">
+                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}">10</a>
+                        </button>
+                        <button class="jenkins-button">
+                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}">25</a>
+                        </button>
+                        <button class="jenkins-button">
+                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}">100</a>
+                        </button>
+                        <button class="jenkins-button">
+                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}">250</a>
+                        </button>
+                        <button class="jenkins-button">
+                          <a href="${request.getRequestURL().toString()}?entriesPerPage=${&quot;all&quot;}">${%all}</a>
+                        </button>
                       </div>
-                    <j:if test="${maxPageNum != 0}">
-                      <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
-                      <div style="float:left; width:55%">
-                        <table  class="jch navigation">
-                          <tr>
-                            <td style=" font-weight:bold; width:60px">Page:</td>
+                    </f:bottomButtonBar>
+                  </div>
+                  <j:if test="${maxPageNum != 0}">
+                    <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
+                    <div style="float:center; width:55%">
+                      <f:bottomButtonBar>
+                        <div class="jenkins-buttons-row">
+                          <h3>"${%Page}:"</h3>
+                          <!--"<" for one step back-->
+                          <j:choose>
+                            <j:when test="${pageNum > 0}">
+                              <button class="jenkins-button">
+                                <a href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
+                              </button>
+                            </j:when>
+                            <j:otherwise>
+                              <button class="jenkins-button dead">
+                                <b>&lt;</b>
+                              </button>
+                            </j:otherwise>
+                          </j:choose>
+
+                          <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
+                          <j:forEach var="currentPageNum" items="${relevantPageNums}">
                             <j:choose>
-                              <!--"<" for one step back-->
-                              <j:when test="${pageNum > 0}">
-                                <td><div class="menu-url-button">
-                                  <a href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
-                                </div></td>
+                              <j:when test="${currentPageNum == -1}">
+                                <button class="jenkins-button dead">
+                                  <b>&#8230;</b>
+                                </button>
+                              </j:when>
+                              <j:when test="${currentPageNum == pageNum}">
+                                <button class="jenkins-button">
+                                  <b>${currentPageNum+1}</b>
+                                </button>
                               </j:when>
                               <j:otherwise>
-                                <td><div class="menu-url-button dead"><b>&lt;</b></div></td>
+                                <button class="jenkins-button">
+                                  <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a>
+                                </button>
                               </j:otherwise>
                             </j:choose>
+                          </j:forEach>
 
-                            <j:forEach var="currentPageNum" items="${relevantPageNums}">
-                              <j:choose>
-                                <j:when test="${currentPageNum == -1}">
-                                  <td><div class="menu-url-button-dead>">&#8230;</div></td>
-                                </j:when>
-                                <j:when test="${currentPageNum == pageNum}">
-                                  <td><div class="menu-url-button current">${currentPageNum+1}</div></td>
-                                </j:when>
-                                <j:otherwise>
-                                  <td><div class="menu-url-button"><a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a></div></td>
-                                </j:otherwise>
-                              </j:choose>
-                            </j:forEach>
+                          <!--">" for one step forward-->
+                          <j:choose>
+                            <j:when test="${maxPageNum > pageNum}">
+                              <button class="jenkins-button">
+                                <a href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
+                              </button>
+                            </j:when>
+                            <j:otherwise>
+                              <button class="jenkins-button dead">
+                                <b>&gt;</b>
+                              </button>
+                            </j:otherwise>
+                          </j:choose>
 
-                            <j:choose>
-                              <!--">" for one step forward-->
-                              <j:when test="${maxPageNum > pageNum}">
-                                <td><div class="menu-url-button">
-                                  <a href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
-                                </div></td>
-                              </j:when>
-                              <j:otherwise>
-                                <td><div class="menu-url-button dead"><b>&gt;</b></div></td>
-                              </j:otherwise>
-                            </j:choose>
-                          </tr>
-                        </table>
-                      </div>
-                    </j:if>
-                    <j:if test="${configs.size() > 1}">
-                      <div style="float:right">
-                        <input class="jch standard-button" type="submit" value="${%Show Diffs}"/>
-                      </div>
-                    </j:if>
-                  </td></tr></table>
+                        </div>
+                      </f:bottomButtonBar>
+                    </div>
+                  </j:if>
+                  <j:if test="${configs.size() > 1}">
+                    <div style="float:right">
+                      <input class="jch standard-button" type="submit" value="${%Show Diffs}"/>
+                    </div>
+                  </j:if>
                 </div>
               </form>
             </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -93,7 +93,7 @@
                           <td style="text-align:left">
                             <j:if test="${!fileMissing}">
                               <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}" class="jenkins-table__link"> ${%View as XML}</a>
-                              <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}" class="jenkins-table__link jenkins-table__badge">${%RAW}</a>
+                              <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}" class="jenkins-table__link jenkins-table__badge">(${%RAW})</a>
                             </j:if>
                           </td>
                           <!-- Restore config -->

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -226,10 +226,10 @@
                     <!-- Show Diff -->
                       <div style="align-self: flex-end">
                   <j:if test="${configs.size() > 1}">
-                        <button type="button" class="jenkins-button">${%Show Diffs}</button>
+                          <button class="jenkins-button">${%Show Diffs}</button>
                   </j:if>
                       <j:if test="${configs.size() == 1 || configs.size() == 0 }">
-                        <button type="button" class="jenkins-button dead">${%Show Diffs}</button>
+                          <button class="jenkins-button dead">${%Show Diffs}</button>
                       </j:if>
                 </div>
                     </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -32,8 +32,7 @@
 
         <j:choose>
           <j:when test="${configs.size() == 0}">
-              ${%No job configuration history available}
-</j:when>
+              ${%No job configuration history available}</j:when>
           <j:otherwise>
             <br />
             <div>
@@ -44,7 +43,7 @@
                       <h2>${it.getProject().getFullName()}</h2>
                     </caption>
                     <thead>
-                      <tr style="position:sticky; top:26px;">
+                      <tr>
                         <th initialSortDir="up" style="text-align:left">${%Date}</th>
                         <th style="text-align:left"> ${%Operation}</th>
                         <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
@@ -108,8 +107,7 @@
                                   <!--The current version is not present in history!-->
                                   <br />
                                   <span style="color: rgb(196, 109, 0); font-weight:bold;">
-                                    ${%Warning}: ${%This is the latest revision in history, but not the current config. Save config to create a current entry.}
-</span>
+                                    ${%Warning}: ${%This is the latest revision in history, but not the current config. Save config to create a current entry.}</span>
                                 </j:if>
                               </j:if>
                             </td>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -2,40 +2,40 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%Job Configuration History}">
 
-    <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css"/>
+    <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css" />
 
     <st:include it="${it.project}" page="sidepanel.jelly" />
     <l:main-panel>
       <h1>${%Job Configuration History}</h1>
       <div>
-        <script src="${rootURL}/plugin/jobConfigHistory/deleteRevisionAndTableEntry.js"/>
-        <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}"/>
-        <j:set var="pageNum" value="${request.getParameter('pageNum')}"/>
-        <j:set var="entriesPerPage" value="${request.getParameter('entriesPerPage')}"/>
-        <j:set var="totalEntriesNumber" value="${it.getRevisionAmount()}"/>
+        <script src="${rootURL}/plugin/jobConfigHistory/deleteRevisionAndTableEntry.js" />
+        <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}" />
+        <j:set var="pageNum" value="${request.getParameter('pageNum')}" />
+        <j:set var="entriesPerPage" value="${request.getParameter('entriesPerPage')}" />
+        <j:set var="totalEntriesNumber" value="${it.getRevisionAmount()}" />
         <j:if test="${pageNum == null or pageNum.equals(&quot;&quot;)}">
-          <j:set var="pageNum" value="0"/>
+          <j:set var="pageNum" value="0" />
         </j:if>
         <j:if test="${entriesPerPage == null or entriesPerPage.equals(&quot;&quot;)}">
-          <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}"/>
+          <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}" />
         </j:if>
         <j:choose>
           <j:when test="${entriesPerPage.equals(&quot;all&quot;)}">
             <j:set var="configs" value="${it.getJobConfigs()}" />
-            <j:set var="maxPageNum" value="${0}"/>
+            <j:set var="maxPageNum" value="${0}" />
           </j:when>
           <j:otherwise>
             <j:set var="configs" value="${it.getJobConfigs(pageNum*entriesPerPage, pageNum*entriesPerPage+entriesPerPage)}" />
-            <j:set var="maxPageNum" value="${it.getMaxPageNum()}"/>
+            <j:set var="maxPageNum" value="${it.getMaxPageNum()}" />
           </j:otherwise>
         </j:choose>
 
         <j:choose>
           <j:when test="${configs.size() == 0}">
               ${%No job configuration history available}
-          </j:when>
+</j:when>
           <j:otherwise>
-            <br/>
+            <br />
             <div>
               <form method="post" action="diffFiles" name="diffFiles">
                 <div>
@@ -62,10 +62,10 @@
                       </tr>
                     </thead>
                     <tbody>
-                      <j:set var="configNr" value="0"/>
+                      <j:set var="configNr" value="0" />
                       <j:forEach var="config" items="${configs}">
-                        <j:set var="configNr" value="${configNr + 1}"/>
-                        <j:set var="fileMissing" value="${!config.hasConfig()}"/>
+                        <j:set var="configNr" value="${configNr + 1}" />
+                        <j:set var="fileMissing" value="${!config.hasConfig()}" />
 
                         <tr class="alternate" id="table-row-${configNr}">
                           <!-- Date -->
@@ -85,40 +85,42 @@
                           </td>
                           <!-- User id -->
                           <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
-                            <td style="text-align:left"><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                            <td style="text-align:left">
+                              <a href="${rootURL}/user/${config.userID}">${config.userID}</a>
+                            </td>
                           </j:if>
                           <!-- Show config -->
                           <td style="text-align:left">
                             <j:if test="${!fileMissing}">
-                              <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}" class="jenkins-table__link"> ${%View as XML} </a>
-                              <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}" class="jenkins-table__link jenkins-table__badge" >${%RAW}</a>
+                              <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}" class="jenkins-table__link"> ${%View as XML}</a>
+                              <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}" class="jenkins-table__link jenkins-table__badge">${%RAW}</a>
                             </j:if>
                           </td>
                           <!-- Restore config -->
                           <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
                             <td style="text-align:center">
-                              <j:set var="revisionEqualsCurrent" value="${it.revisionEqualsCurrent(config.getDate())}"/>
+                              <j:set var="revisionEqualsCurrent" value="${it.revisionEqualsCurrent(config.getDate())}" />
                               <j:if test="${!revisionEqualsCurrent and !fileMissing}">
                                 <a href="restoreQuestion?timestamp=${config.getDate()}" class="jenkins-table__link">
-                                  <l:icon id="restore${configNr}" src="symbol-restore plugin-jobConfigHistory" class="icon-md" title="${%Restore}"  />
+                                  <l:icon id="restore${configNr}" src="symbol-restore plugin-jobConfigHistory" class="icon-md" title="${%Restore}" />
                                 </a>
                                 <j:if test="${configNr == 1 and pageNum == 0}">
                                   <!--The current version is not present in history!-->
-                                  <br/>
+                                  <br />
                                   <span style="color: rgb(196, 109, 0); font-weight:bold;">
                                     ${%Warning}: ${%This is the latest revision in history, but not the current config. Save config to create a current entry.}
-                                  </span>
+</span>
                                 </j:if>
                               </j:if>
                             </td>
                           </j:if>
                           <j:if test="${configNr == 2 and fileMissing}">
-                            <j:set var="offsetIfFileMissing" value="1"/>
+                            <j:set var="offsetIfFileMissing" value="1" />
                           </j:if>
                           <!-- File A -->
                           <td style="text-align:center">
                             <j:if test="${!fileMissing}">
-                              <f:radio  name="timestamp1" value="${config.getDate()}" checked="${configNr == (2 + offsetIfFileMissing) ? true:false}" />
+                              <f:radio name="timestamp1" value="${config.getDate()}" checked="${configNr == (2 + offsetIfFileMissing) ? true:false}" />
                             </j:if>
                           </td>
                           <!-- File B -->
@@ -130,7 +132,7 @@
                           <!-- Trash icon -->
                           <td style="text-align:center">
                             <j:if test="${it.hasDeleteEntryPermission()}">
-                              <j:set var="message" value="${%Do you really want to delete the history entry} "/>
+                              <j:set var="message" value="${%Do you really want to delete the history entry} " />
                               <button type="button" class="jenkins-button jenkins-button--destructive" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
                                 <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}" />
                               </button>
@@ -146,7 +148,7 @@
                 </div>
                 <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
                 <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
-                    <f:bottomButtonBar>
+                <f:bottomButtonBar>
                   <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
 
                     <!-- Page view filter selector -->
@@ -162,12 +164,12 @@
                           </j:otherwise>
                         </j:choose>
                       </j:forEach>
-                      </div>
+                    </div>
                     <div style="display: flex; justify-content: flex-end">
-                    <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
-                    <div>
-                      <j:if test="${maxPageNum != 0}">
-                            <h3>${%Page}:</h3>
+                      <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
+                      <div>
+                        <j:if test="${maxPageNum != 0}">
+                          <h3>${%Page}:</h3>
 
                           <!--"<" for one step back-->
                           <j:choose>
@@ -210,15 +212,15 @@
                               </a>
                             </j:otherwise>
                           </j:choose>
-                      </j:if>
-                        </div>
+                        </j:if>
+                      </div>
 
-                    <!-- Show Diff -->
+                      <!-- Show Diff -->
                       <div style="align-self: flex-end">
-                  <j:if test="${configs.size() > 1}">
+                        <j:if test="${configs.size() > 1}">
                           <button class="jenkins-button">${%Show Diffs}</button>
-                  </j:if>
-                </div>
+                        </j:if>
+                      </div>
                     </div>
 
                   </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -143,12 +143,11 @@
                     </tbody>
                   </table>
                 </div>
-                <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}"/>
-                <div class="jch-footer">
-                  <div style="float:left; width:30%">
+                <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
                     <f:bottomButtonBar>
-                      <div class="jenkins-buttons-row">
-                        <h3>"${%Entries per page}:"</h3>
+                  <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
+                    <div>
+                      <h3>${%Entries per page}:</h3>
                         <button type="button" class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}">10</a>
                         </button>
@@ -165,19 +164,19 @@
                           <a href="${request.getRequestURL().toString()}?entriesPerPage=${&quot;all&quot;}">${%all}</a>
                         </button>
                       </div>
-                    </f:bottomButtonBar>
-                  </div>
-                  <j:if test="${maxPageNum != 0}">
+
+                    <div style="display: flex; justify-content: flex-end">
                     <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
-                    <div style="float:center; width:55%">
-                      <f:bottomButtonBar>
-                        <div class="jenkins-buttons-row">
-                          <h3>"${%Page}:"</h3>
+                    <div>
+                      <j:if test="${maxPageNum != 0}">
+                            <h3>${%Page}:</h3>
                           <!--"<" for one step back-->
                           <j:choose>
                             <j:when test="${pageNum > 0}">
                               <button type="button" class="jenkins-button">
-                                <a href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
+                              <a href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}">
+                                <b>&lt;</b>
+                              </a>
                               </button>
                             </j:when>
                             <j:otherwise>
@@ -196,9 +195,7 @@
                                 </button>
                               </j:when>
                               <j:when test="${currentPageNum == pageNum}">
-                                <button type="button" class="jenkins-button current">
-                                  ${currentPageNum+1}
-                                </button>
+                              <button type="button" class="jenkins-button current">${currentPageNum+1}</button>
                               </j:when>
                               <j:otherwise>
                                 <button type="button" class="jenkins-button">
@@ -212,7 +209,9 @@
                           <j:choose>
                             <j:when test="${maxPageNum > pageNum}">
                               <button type="button" class="jenkins-button">
-                                <a href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
+                              <a href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}">
+                                <b>&gt;</b>
+                              </a>
                               </button>
                             </j:when>
                             <j:otherwise>
@@ -221,17 +220,22 @@
                               </button>
                             </j:otherwise>
                           </j:choose>
-
+                      </j:if>
                         </div>
-                      </f:bottomButtonBar>
-                    </div>
-                  </j:if>
+
+                    <!-- Show Diff -->
+                      <div style="align-self: flex-end">
                   <j:if test="${configs.size() > 1}">
-                    <div style="float:right">
-                      <input class="jch standard-button" type="submit" value="${%Show Diffs}"/>
-                    </div>
+                        <button type="button" class="jenkins-button">${%Show Diffs}</button>
                   </j:if>
+                      <j:if test="${configs.size() == 1 || configs.size() == 0 }">
+                        <button type="button" class="jenkins-button dead">${%Show Diffs}</button>
+                      </j:if>
                 </div>
+                    </div>
+
+                  </div>
+                </f:bottomButtonBar>
               </form>
             </div>
           </j:otherwise>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -222,9 +222,6 @@
                   <j:if test="${configs.size() > 1}">
                           <button class="jenkins-button">${%Show Diffs}</button>
                   </j:if>
-                      <j:if test="${configs.size() == 1 || configs.size() == 0 }">
-                          <button class="jenkins-button jenkins-button--transparent">${%Show Diffs}</button>
-                      </j:if>
                 </div>
                     </div>
 

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -130,7 +130,7 @@
                           <td style="text-align:center">
                             <j:if test="${it.hasDeleteEntryPermission()}">
                               <j:set var="message" value="${%Do you really want to delete the history entry} "/>
-                              <button class="jenkins-button jenkins-button--transparent" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
+                              <button type="button" class="jenkins-button jenkins-button--transparent" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
                                 <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}"/>
                               </button>
                             </j:if>
@@ -149,19 +149,19 @@
                     <f:bottomButtonBar>
                       <div class="jenkins-buttons-row">
                         <h3>"${%Entries per page}:"</h3>
-                        <button class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
+                        <button type="button" class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}">10</a>
                         </button>
-                        <button class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
+                        <button type="button" class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}">25</a>
                         </button>
-                        <button class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
+                        <button type="button" class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}">100</a>
                         </button>
-                        <button class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
+                        <button type="button" class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}">250</a>
                         </button>
-                        <button class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
+                        <button type="button" class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?entriesPerPage=${&quot;all&quot;}">${%all}</a>
                         </button>
                       </div>
@@ -176,12 +176,12 @@
                           <!--"<" for one step back-->
                           <j:choose>
                             <j:when test="${pageNum > 0}">
-                              <button class="jenkins-button">
+                              <button type="button" class="jenkins-button">
                                 <a href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
                               </button>
                             </j:when>
                             <j:otherwise>
-                              <button class="jenkins-button dead">
+                              <button type="button" class="jenkins-button dead">
                                 <b>&lt;</b>
                               </button>
                             </j:otherwise>
@@ -191,17 +191,17 @@
                           <j:forEach var="currentPageNum" items="${relevantPageNums}">
                             <j:choose>
                               <j:when test="${currentPageNum == -1}">
-                                <button class="jenkins-button dead">
+                                <button type="button" class="jenkins-button dead">
                                   <b>&#8230;</b>
                                 </button>
                               </j:when>
                               <j:when test="${currentPageNum == pageNum}">
-                                <button class="jenkins-button current">
-                                  <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a>
+                                <button type="button" class="jenkins-button current">
+                                  ${currentPageNum+1}
                                 </button>
                               </j:when>
                               <j:otherwise>
-                                <button class="jenkins-button">
+                                <button type="button" class="jenkins-button">
                                   <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a>
                                 </button>
                               </j:otherwise>
@@ -211,12 +211,12 @@
                           <!--">" for one step forward-->
                           <j:choose>
                             <j:when test="${maxPageNum > pageNum}">
-                              <button class="jenkins-button">
+                              <button type="button" class="jenkins-button">
                                 <a href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
                               </button>
                             </j:when>
                             <j:otherwise>
-                              <button class="jenkins-button dead">
+                              <button type="button" class="jenkins-button dead">
                                 <b>&gt;</b>
                               </button>
                             </j:otherwise>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -13,7 +13,6 @@
         <j:set var="pageNum" value="${request.getParameter('pageNum')}" />
         <j:set var="entriesPerPage" value="${request.getParameter('entriesPerPage')}" />
         <j:set var="totalEntriesNumber" value="${it.getRevisionAmount()}" />
-        <j:set var="requestUrl" value="${rootURL}${request.getPathInfo().toString()}"/>
         <j:if test="${pageNum == null or pageNum.equals(&quot;&quot;)}">
           <j:set var="pageNum" value="0" />
         </j:if>
@@ -158,10 +157,10 @@
                       <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
                         <j:choose>
                           <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
-                            <a class="jenkins-button jenkins-button--primary" href="${requestUrl}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                            <a class="jenkins-button jenkins-button--primary" href="?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
                           </j:when>
                           <j:otherwise>
-                            <a class="jenkins-button" href="${requestUrl}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                            <a class="jenkins-button" href="?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
                           </j:otherwise>
                         </j:choose>
                       </j:forEach>
@@ -175,7 +174,7 @@
                           <!--"<" for one step back-->
                           <j:choose>
                             <j:when test="${pageNum > 0}">
-                              <a class="jenkins-button" href="${requestUrl}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                              <a class="jenkins-button" href="?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                 <b>&lt;</b>
                               </a>
                             </j:when>
@@ -194,7 +193,7 @@
                                   ${currentPageNum+1}</a>
                               </j:when>
                               <j:otherwise>
-                                <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>
                               </j:otherwise>
                             </j:choose>
@@ -203,7 +202,7 @@
                           <!--">" for one step forward-->
                           <j:choose>
                             <j:when test="${maxPageNum > pageNum}">
-                              <a class="jenkins-button" href="${requestUrl}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                              <a class="jenkins-button" href="?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                 <b>&gt;</b>
                               </a>
                             </j:when>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -144,24 +144,24 @@
                   </table>
                 </div>
                 <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
+                <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
                     <f:bottomButtonBar>
                   <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
 
                     <!-- Page view filter selector -->
                     <div>
                       <h3>${%Entries per page}:</h3>
-                      <a class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}" rel="noopener noreferrer">
-                        10</a>
-                      <a class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}" rel="noopener noreferrer">
-                        25</a>
-                      <a class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}" rel="noopener noreferrer">
-                        100</a>
-                      <a class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}" rel="noopener noreferrer">
-                        250</a>
-                      <a class="${(entriesPerPage.equals(&quot;${%all}&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${%all}" rel="noopener noreferrer">
-                        ${%all}</a>
+                      <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
+                        <j:choose>
+                          <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
+                            <a class="jenkins-button jenkins-button--primary" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                          </j:when>
+                          <j:otherwise>
+                            <a class="jenkins-button" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                          </j:otherwise>
+                        </j:choose>
+                      </j:forEach>
                       </div>
-
                     <div style="display: flex; justify-content: flex-end">
                     <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
                     <div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -132,8 +132,7 @@
                             <j:if test="${it.hasDeleteEntryPermission()}">
                               <j:set var="message" value="${%Do you really want to delete the history entry} "/>
                               <button type="button" class="jenkins-button jenkins-button--destructive" onClick="removeEntryFromTable('table-row-${configNr}', '${config.date}', 'null', '${message}')" value="X">
-
-                                <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}"/>
+                                <l:icon src="symbol-trash" class="icon-md" alt="${%Delete Revision}" />
                               </button>
                             </j:if>
                           </td>
@@ -178,7 +177,7 @@
                               </a>
                             </j:when>
                             <j:otherwise>
-                              <a class="jenkins-button jenkins-button--transparent" rel="noopener noreferrer">
+                              <a class="jenkins-button" rel="noopener noreferrer">
                                 <b>&lt;</b>
                               </a>
                             </j:otherwise>
@@ -187,11 +186,6 @@
                           <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
                           <j:forEach var="currentPageNum" items="${relevantPageNums}">
                             <j:choose>
-                              <j:when test="${currentPageNum == -1}">
-                                <a class="jenkins-button jenkins-button--transparent" rel="noopener noreferrer">
-                                  <b>&#8230;</b>
-                                </a>
-                              </j:when>
                               <j:when test="${currentPageNum == pageNum}">
                                 <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>
@@ -211,7 +205,7 @@
                               </a>
                             </j:when>
                             <j:otherwise>
-                              <a class="jenkins-button jenkins-button--transparent" rel="noopener noreferrer">
+                              <a class="jenkins-button" rel="noopener noreferrer">
                                 <b>&gt;</b>
                               </a>
                             </j:otherwise>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -65,6 +65,8 @@
                       <j:set var="configNr" value="0"/>
                       <j:forEach var="config" items="${configs}">
                         <j:set var="configNr" value="${configNr + 1}"/>
+                        <j:set var="fileMissing" value="${!config.hasConfig()}"/>
+
                         <tr class="alternate" id="table-row-${configNr}">
                           <!-- Date -->
                           <td style="text-align:left">${config.date}</td>
@@ -86,7 +88,6 @@
                             <td style="text-align:left"><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
                           </j:if>
                           <!-- Show config -->
-                          <j:set var="fileMissing" value="${!config.hasConfig()}"/>
                           <td style="text-align:left">
                             <j:if test="${!fileMissing}">
                               <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}" class="jenkins-table__link"> ${%View as XML} </a>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -39,7 +39,7 @@
             <div>
               <form method="post" action="diffFiles" name="diffFiles">
                 <div>
-                  <table id="confighistory" class="jenkins-table sortable jenkins-!-margin-bottom-0">
+                  <table id="confighistory" class="jenkins-table sortable">
                     <caption class="caption">
                       <h2>${it.getProject().getFullName()}</h2>
                     </caption>
@@ -86,8 +86,8 @@
                             <td style="text-align:left"><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
                           </j:if>
                           <!-- Show config -->
+                          <j:set var="fileMissing" value="${!config.hasConfig()}"/>
                           <td style="text-align:left">
-                            <j:set var="fileMissing" value="${!config.hasConfig()}"/>
                             <j:if test="${!fileMissing}">
                               <a href="configOutput?type=xml&amp;timestamp=${config.getDate()}" class="jenkins-table__link"> ${%View as XML} </a>
                               <a href="configOutput?type=raw&amp;timestamp=${config.getDate()}" class="jenkins-table__link jenkins-table__badge" >${%RAW}</a>
@@ -149,19 +149,19 @@
                     <f:bottomButtonBar>
                       <div class="jenkins-buttons-row">
                         <h3>"${%Entries per page}:"</h3>
-                        <button class="jenkins-button">
+                        <button class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}">10</a>
                         </button>
-                        <button class="jenkins-button">
+                        <button class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}">25</a>
                         </button>
-                        <button class="jenkins-button">
+                        <button class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}">100</a>
                         </button>
-                        <button class="jenkins-button">
+                        <button class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}">250</a>
                         </button>
-                        <button class="jenkins-button">
+                        <button class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
                           <a href="${request.getRequestURL().toString()}?entriesPerPage=${&quot;all&quot;}">${%all}</a>
                         </button>
                       </div>
@@ -196,8 +196,8 @@
                                 </button>
                               </j:when>
                               <j:when test="${currentPageNum == pageNum}">
-                                <button class="jenkins-button">
-                                  <b>${currentPageNum+1}</b>
+                                <button class="jenkins-button current">
+                                  <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a>
                                 </button>
                               </j:when>
                               <j:otherwise>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -146,23 +146,20 @@
                 <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
                     <f:bottomButtonBar>
                   <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
+
+                    <!-- Page view filter selector -->
                     <div>
                       <h3>${%Entries per page}:</h3>
-                        <button type="button" class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
-                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}">10</a>
-                        </button>
-                        <button type="button" class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
-                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}">25</a>
-                        </button>
-                        <button type="button" class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
-                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}">100</a>
-                        </button>
-                        <button type="button" class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
-                          <a href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}">250</a>
-                        </button>
-                        <button type="button" class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;jenkins-button current&quot;) : &quot;jenkins-button&quot;} ">
-                          <a href="${request.getRequestURL().toString()}?entriesPerPage=${&quot;all&quot;}">${%all}</a>
-                        </button>
+                      <a class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${10}" rel="noopener noreferrer">
+                        10</a>
+                      <a class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${25}" rel="noopener noreferrer">
+                        25</a>
+                      <a class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${100}" rel="noopener noreferrer">
+                        100</a>
+                      <a class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${250}" rel="noopener noreferrer">
+                        250</a>
+                      <a class="${(entriesPerPage.equals(&quot;${%all}&quot;)) ? (&quot;jenkins-button jenkins-button--primary&quot;) : &quot;jenkins-button&quot;}" href="${request.getRequestURL().toString()}?pageNum=${0}&amp;entriesPerPage=${%all}" rel="noopener noreferrer">
+                        ${%all}</a>
                       </div>
 
                     <div style="display: flex; justify-content: flex-end">
@@ -170,19 +167,18 @@
                     <div>
                       <j:if test="${maxPageNum != 0}">
                             <h3>${%Page}:</h3>
+
                           <!--"<" for one step back-->
                           <j:choose>
                             <j:when test="${pageNum > 0}">
-                              <button type="button" class="jenkins-button">
-                              <a href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}">
+                              <a class="jenkins-button" href="${request.getRequestURL().toString()}?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                 <b>&lt;</b>
                               </a>
-                              </button>
                             </j:when>
                             <j:otherwise>
-                              <button type="button" class="jenkins-button dead">
+                              <a class="jenkins-button jenkins-button--transparent" rel="noopener noreferrer">
                                 <b>&lt;</b>
-                              </button>
+                              </a>
                             </j:otherwise>
                           </j:choose>
 
@@ -190,17 +186,17 @@
                           <j:forEach var="currentPageNum" items="${relevantPageNums}">
                             <j:choose>
                               <j:when test="${currentPageNum == -1}">
-                                <button type="button" class="jenkins-button dead">
+                                <a class="jenkins-button jenkins-button--transparent" rel="noopener noreferrer">
                                   <b>&#8230;</b>
-                                </button>
+                                </a>
                               </j:when>
                               <j:when test="${currentPageNum == pageNum}">
-                              <button type="button" class="jenkins-button current">${currentPageNum+1}</button>
+                                <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
+                                  ${currentPageNum+1}</a>
                               </j:when>
                               <j:otherwise>
-                                <button type="button" class="jenkins-button">
-                                  <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a>
-                                </button>
+                                <a class="jenkins-button" href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                  ${currentPageNum+1}</a>
                               </j:otherwise>
                             </j:choose>
                           </j:forEach>
@@ -208,16 +204,14 @@
                           <!--">" for one step forward-->
                           <j:choose>
                             <j:when test="${maxPageNum > pageNum}">
-                              <button type="button" class="jenkins-button">
-                              <a href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}">
+                              <a class="jenkins-button" href="${request.getRequestURL().toString()}?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                 <b>&gt;</b>
                               </a>
-                              </button>
                             </j:when>
                             <j:otherwise>
-                              <button type="button" class="jenkins-button dead">
+                              <a class="jenkins-button jenkins-button--transparent" rel="noopener noreferrer">
                                 <b>&gt;</b>
-                              </button>
+                              </a>
                             </j:otherwise>
                           </j:choose>
                       </j:if>
@@ -229,7 +223,7 @@
                           <button class="jenkins-button">${%Show Diffs}</button>
                   </j:if>
                       <j:if test="${configs.size() == 1 || configs.size() == 0 }">
-                          <button class="jenkins-button dead">${%Show Diffs}</button>
+                          <button class="jenkins-button jenkins-button--transparent">${%Show Diffs}</button>
                       </j:if>
                 </div>
                     </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -5,8 +5,8 @@
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css" />
 
     <st:include it="${it.project}" page="sidepanel.jelly" />
+    <l:app-bar title="${%Job Configuration History}"/>
     <l:main-panel>
-      <h1>${%Job Configuration History}</h1>
       <div>
         <script src="${rootURL}/plugin/jobConfigHistory/deleteRevisionAndTableEntry.js" />
         <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}" />

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -146,19 +146,19 @@
                             <td style="width:150px; font-weight:bold;">${%Entries per page}:</td>
                             <!--                          <td><div class="menu-url-button current">${entriesPerPage}</div></td>-->
                             <td><div class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${10}">10</a>
+                              <a href="?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${10}">10</a>
                             </div></td>
                             <td><div class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${25}">25</a>
+                              <a href="?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${25}">25</a>
                             </div></td>
                             <td><div class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${100}">100</a>
+                              <a href="?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${100}">100</a>
                             </div></td>
                             <td><div class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${250}">250</a>
+                              <a href="?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${250}">250</a>
                             </div></td>
                             <td><div class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                              <a href="${request.getRequestURL().toString()}?name=${name}&amp;entriesPerPage=${&quot;all&quot;}">
+                              <a href="?name=${name}&amp;entriesPerPage=${&quot;all&quot;}">
                                 ${%all}</a>
                             </div></td>
                           </tr>
@@ -175,7 +175,7 @@
                               <!--"<" for one step back-->
                               <j:when test="${pageNum > 0}">
                                 <td><div class="menu-url-button">
-                                  <a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
+                                  <a href="?name=${name}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
                                 </div></td>
                               </j:when>
                               <j:otherwise>
@@ -192,7 +192,7 @@
                                   <td><div class="menu-url-button current">${currentPageNum+1}</div></td>
                                 </j:when>
                                 <j:otherwise>
-                                  <td><div class="menu-url-button"><a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a></div></td>
+                                  <td><div class="menu-url-button"><a href="?name=${name}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a></div></td>
                                 </j:otherwise>
                               </j:choose>
                             </j:forEach>
@@ -201,7 +201,7 @@
                               <!--">" for one step forward-->
                               <j:when test="${maxPageNum > pageNum}">
                                 <td><div class="menu-url-button">
-                                  <a href="${request.getRequestURL().toString()}?name=${name}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
+                                  <a href="?name=${name}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
                                 </div></td>
                               </j:when>
                               <j:otherwise>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -71,26 +71,22 @@
             ${%No configuration history available}</j:when>
           <j:otherwise>
             <div>
-              <table class="jenkins-table sortable" style="width:100%;">
+              <table class="jenkins-table sortable">
                 <thead>
-                  <tr style="position:sticky; top:66px;">
-                    <th initialSortDir="up">${%Date}</th>
-                    <j:choose>
-                      <j:when test="${filter == 'jobs' || filter == 'deleted' || filter == 'created'}">
-                        <th>${%Job configuration}</th>
-                      </j:when>
-                      <j:when test="${filter == 'all'}">
-                        <th>${%Job and system configuration}</th>
-                      </j:when>
-                      <j:otherwise>
-                        <th>${%System configuration}</th>
-                      </j:otherwise>
-                    </j:choose>
-                    <th>${%Operation}</th>
+                  <tr>
+                    <th initialSortDir="up" style="text-align:left">${%Date}</th>
+                    <th style="text-align:left">
+                      <j:choose>
+                        <j:when test="${filter == 'jobs' || filter == 'deleted' || filter == 'created'}">${%Job configuration}</j:when>
+                        <j:when test="${filter == 'all'}">${%Job and system configuration}</j:when>
+                        <j:otherwise>${%System configuration}</j:otherwise>
+                      </j:choose>
+                    </th>
+                    <th style="text-align:left">${%Operation}</th>
                     <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
-                      <th>${%User}</th>
+                      <th style="text-align:left">${%User}</th>
                     </j:if>
-                    <th>${%File(raw)}</th>
+                    <th style="text-align:left">${%File(RAW)}</th>
                     <j:if test="${filter == 'deleted'}">
                       <th style="text-align:center">${%Restore project}</th>
                     </j:if>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -63,17 +63,13 @@
       </j:choose>
 
       <div>
-
         <j:choose>
           <j:when test="${!it.hasConfigurePermission() and (filter == 'system' || filter == null)}">
-            ${%No permission to view system changes}
-</j:when>
+            ${%No permission to view system changes}</j:when>
           <j:when test="${!it.hasJobConfigurePermission() and !it.hasReadExtensionPermission()}">
-            ${%No permission to view config history}
-</j:when>
+            ${%No permission to view config history}</j:when>
           <j:when test="${configs.size() == 0}">
-            ${%No configuration history available}
-</j:when>
+            ${%No configuration history available}</j:when>
           <j:otherwise>
             <div>
               <table class="jenkins-table sortable" style="width:100%;">
@@ -144,8 +140,7 @@
                       <a href="${it.createLinkToFiles(config,'xml')}"> ${%View as XML}</a>
                       <st:nbsp />
                       <a href="${it.createLinkToFiles(config,'raw')}">
-                        (${%RAW})
-</a>
+                        (${%RAW})</a>
                     </td>
                     <j:if test="${filter == 'deleted'}">
                       <td style="text-align:center">
@@ -167,8 +162,10 @@
                   </tr>
                 </j:forEach>
               </table>
+
               <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
               <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
+
               <f:bottomButtonBar>
                 <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
                   <!-- Page view filter selector -->

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%All Configuration History}">
 
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css"/>
@@ -15,26 +15,30 @@
         <l:task icon="icon-document icon-md" href="?filter=all" title="${%Show all configs}" />
       </l:tasks>
     </l:side-panel>
+
+    <j:set var="requestUrl" value="${rootURL}${request.getPathInfo().toString()}"/>
+    <j:set var="filter" value="${request.getParameter('filter')}"/>
+    <j:set var="filter" value="${filter == null ? 'system' : filter}"/>
+
+    <j:choose>
+      <j:when test="${filter == 'all'}">
+        <l:app-bar title="${%All Configuration History}"></l:app-bar>
+      </j:when>
+      <j:when test="${filter == 'jobs'}">
+        <l:app-bar title="${%Job Configuration History}"></l:app-bar>
+      </j:when>
+      <j:when test="${filter == 'created'}">
+        <l:app-bar title="${%Job Creation History}"></l:app-bar>
+      </j:when>
+      <j:when test="${filter == 'deleted'}">
+        <l:app-bar title="${%Job Deletion History}"></l:app-bar>
+      </j:when>
+      <j:otherwise>
+        <l:app-bar title="${%All Configuration History}"></l:app-bar>
+      </j:otherwise>
+    </j:choose>
+
     <l:main-panel>
-      <j:set var="filter" value="${request.getParameter('filter')}"/>
-      <j:set var="filter" value="${filter == null ? 'system' : filter}"/>
-      <j:choose>
-        <j:when test="${filter == 'all'}">
-          <h1>${%All Configuration History}</h1>
-        </j:when>
-        <j:when test="${filter == 'jobs'}">
-          <h1>${%Job Configuration History}</h1>
-        </j:when>
-        <j:when test="${filter == 'created'}">
-          <h1>${%Job Creation History}</h1>
-        </j:when>
-        <j:when test="${filter == 'deleted'}">
-          <h1>${%Job Deletion History}</h1>
-        </j:when>
-        <j:otherwise>
-          <h1>${%System Configuration History}</h1>
-        </j:otherwise>
-      </j:choose>
 
       <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}"/>
       <j:set var="pageNum" value="${request.getParameter('pageNum')}"/>
@@ -45,7 +49,7 @@
         <j:set var="pageNum" value="0"/>
       </j:if>
       <j:if test="${entriesPerPage == null or entriesPerPage.equals(&quot;&quot;)}">
-        <j:set var="entriesPerPage" value="${defaultEntriesPerPage}"/>
+        <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}"/>
       </j:if>
       <j:choose>
         <j:when test="${entriesPerPage.equals(&quot;all&quot;) or filter.equals(&quot;created&quot;)}">
@@ -58,50 +62,6 @@
         </j:otherwise>
       </j:choose>
 
-      <div style="position:sticky; top:26px; z-index:1">
-        <table style="width:100%" class="header-content-wrapper">
-          <j:set var="selectedStyleEntry" value="font-size:14px"/>
-          <j:set var="unSelectedStyleEntry" value=""/>
-
-          <tr>
-            <td>
-              <j:set var="currentFilterSelected" value="${(filter.equalsIgnoreCase(&quot;system&quot;))}"/>
-              <div class="${(currentFilterSelected) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                <a href="?filter=system&amp;pageNum=0&amp;entriesPerPage=${entriesPerPage}" style="text-decoration:none; ${(currentFilterSelected) ? selectedStyleEntry : unselectedStyleEntry}">
-                  ${%Show system configs only}</a>
-              </div>
-            </td>
-            <td>
-              <j:set var="currentFilterSelected" value="${(filter.equalsIgnoreCase(&quot;jobs&quot;))}"/>
-              <div class="${(currentFilterSelected) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                <a href="?filter=jobs&amp;pageNum=0&amp;entriesPerPage=${entriesPerPage}" style="text-decoration:none; ${(currentFilterSelected) ? selectedStyleEntry : unselectedStyleEntry}">
-                  ${%Show job configs only}</a>
-              </div>
-            </td>
-            <td>
-              <j:set var="currentFilterSelected" value="${(filter.equalsIgnoreCase(&quot;created&quot;))}"/>
-              <div class="${(currentFilterSelected) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                <a href="?filter=created&amp;pageNum=0&amp;entriesPerPage=${entriesPerPage}" style="text-decoration:none; ${(currentFilterSelected) ? selectedStyleEntry : unselectedStyleEntry}">
-                  ${%Show created jobs only}</a>
-              </div>
-            </td>
-            <td>
-              <j:set var="currentFilterSelected" value="${(filter.equalsIgnoreCase(&quot;deleted&quot;))}"/>
-              <div class="${(currentFilterSelected) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                <a href="?filter=deleted&amp;pageNum=0&amp;entriesPerPage=${entriesPerPage}" style="text-decoration:none; ${(currentFilterSelected) ? selectedStyleEntry : unselectedStyleEntry}">
-                  ${%Show deleted jobs only}</a>
-              </div>
-            </td>
-            <td>
-              <j:set var="currentFilterSelected" value="${(filter.equalsIgnoreCase(&quot;all&quot;))}"/>
-              <div class="${(currentFilterSelected) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                <a href="?filter=all&amp;pageNum=0&amp;entriesPerPage=${entriesPerPage}" style="text-decoration:none; ${(currentFilterSelected) ? selectedStyleEntry : unselectedStyleEntry}">
-                  ${%Show all configs}</a>
-              </div>
-            </td>
-          </tr>
-        </table>
-      </div>
       <div>
 
         <j:choose>
@@ -116,7 +76,7 @@
           </j:when>
           <j:otherwise>
             <div>
-              <table class="pane sortable jch" style="width:100%;">
+              <table class="jenkins-table sortable" style="width:100%;">
                 <thead>
                   <tr style="position:sticky; top:66px;">
                     <th initialSortDir="up" >${%Date}</th>
@@ -201,83 +161,77 @@
                 </j:forEach>
               </table>
               <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}"/>
-              <div class="jch-footer">
-                <table class="footer-content-wrapper"><tr><td style="padding:0px;">
-                  <j:if test="${!filter.equals(&quot;created&quot;)}">
-                    <div style="float:left; width:34%">
-                      <table class="jch navigation">
-                        <tr>
-                          <td style="width:150px; font-weight:bold;">${%Entries per page}:</td>
-<!--                          <td><div class="menu-url-button current">${entriesPerPage}</div></td>-->
-                          <td><div class="${(entriesPerPage.equals(&quot;10&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                            <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${10}">10</a>
-                          </div></td>
-                          <td><div class="${(entriesPerPage.equals(&quot;25&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                            <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${25}">25</a>
-                          </div></td>
-                          <td><div class="${(entriesPerPage.equals(&quot;100&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                            <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${100}">100</a>
-                          </div></td>
-                          <td><div class="${(entriesPerPage.equals(&quot;250&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                            <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${250}">250</a>
-                          </div></td>
-                          <td><div class="${(entriesPerPage.equals(&quot;all&quot;)) ? (&quot;menu-url-button current&quot;) : &quot;menu-url-button&quot;}">
-                            <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;entriesPerPage=${&quot;all&quot;}">
-                              ${%all}</a>
-                          </div></td>
-                        </tr>
-                      </table>
+              <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
+              <f:bottomButtonBar>
+                <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
+                    <!-- Page view filter selector -->
+                    <div>
+                      <j:if test="${!filter.equals(&quot;created&quot;)}">
+                      <h3>${%Entries per page}:</h3>
+                      <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
+                        <j:choose>
+                          <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
+                            <a class="jenkins-button jenkins-button--primary" href="${requestUrl}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                          </j:when>
+                          <j:otherwise>
+                            <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                          </j:otherwise>
+                        </j:choose>
+                      </j:forEach>
+                      </j:if>
                     </div>
-                  </j:if>
-                  <j:if test="${maxPageNum != 0}">
+
                     <!--page navigation-->
-                    <div style="float:right; width:65%">
-                      <table  class="jch navigation">
-                        <tr>
-                          <td style=" font-weight:bold; width:60px">Page:</td>
+                    <div>
+                      <j:if test="${maxPageNum != 0}">
+                          <h3>${%Page}:</h3>
+
+                          <!--"<" for one step back-->
                           <j:choose>
-                            <!--"<" for one step back-->
                             <j:when test="${pageNum > 0}">
-                              <td><div class="menu-url-button">
-                                <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}"><b>&lt;</b></a>
-                              </div></td>
+                              <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                <b>&lt;</b>
+                              </a>
                             </j:when>
                             <j:otherwise>
-                              <td><div class="menu-url-button dead"><b>&lt;</b></div></td>
+                              <a class="jenkins-button" rel="noopener noreferrer">
+                                <b>&lt;</b>
+                              </a>
                             </j:otherwise>
                           </j:choose>
 
+                          <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
                           <j:forEach var="currentPageNum" items="${relevantPageNums}">
                             <j:choose>
-                              <j:when test="${currentPageNum == -1}">
-                                <td><div class="menu-url-button-dead>">&#8230;</div></td>
-                              </j:when>
                               <j:when test="${currentPageNum == pageNum}">
-                                <td><div class="menu-url-button current">${currentPageNum+1}</div></td>
+                                <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
+                                  ${currentPageNum+1}</a>
                               </j:when>
                               <j:otherwise>
-                                <td><div class="menu-url-button"><a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}">${currentPageNum+1}</a></div></td>
+                                <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                  ${currentPageNum+1}</a>
                               </j:otherwise>
                             </j:choose>
                           </j:forEach>
 
+                          <!--">" for one step forward-->
                           <j:choose>
-                            <!--">" for one step forward-->
                             <j:when test="${maxPageNum > pageNum}">
-                              <td><div class="menu-url-button">
-                                <a href="${request.getRequestURL().toString()}?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}"><b>&gt;</b></a>
-                              </div></td>
+                              <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                <b>&gt;</b>
+                              </a>
                             </j:when>
                             <j:otherwise>
-                              <td><div class="menu-url-button dead"><b>&gt;</b></div></td>
+                              <a class="jenkins-button" rel="noopener noreferrer">
+                                <b>&gt;</b>
+                              </a>
                             </j:otherwise>
                           </j:choose>
-                        </tr>
-                      </table>
+                      </j:if>
                     </div>
-                  </j:if>
-                </td></tr></table>
-              </div>
+                </div>
+              </f:bottomButtonBar>
+
             </div>
           </j:otherwise>
         </j:choose>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -16,7 +16,6 @@
       </l:tasks>
     </l:side-panel>
 
-    <j:set var="requestUrl" value="${rootURL}${request.getPathInfo().toString()}" />
     <j:set var="filter" value="${request.getParameter('filter')}" />
     <j:set var="filter" value="${filter == null ? 'system' : filter}" />
 
@@ -175,10 +174,10 @@
                       <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
                         <j:choose>
                           <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
-                            <a class="jenkins-button jenkins-button--primary" href="${requestUrl}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                            <a class="jenkins-button jenkins-button--primary" href="?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
                           </j:when>
                           <j:otherwise>
-                            <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                            <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
                           </j:otherwise>
                         </j:choose>
                       </j:forEach>
@@ -193,7 +192,7 @@
                       <!--"<" for one step back-->
                       <j:choose>
                         <j:when test="${pageNum > 0}">
-                          <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                          <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                             <b>&lt;</b>
                           </a>
                         </j:when>
@@ -212,7 +211,7 @@
                                   ${currentPageNum+1}</a>
                           </j:when>
                           <j:otherwise>
-                            <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                            <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>
                           </j:otherwise>
                         </j:choose>
@@ -221,7 +220,7 @@
                       <!--">" for one step forward-->
                       <j:choose>
                         <j:when test="${maxPageNum > pageNum}">
-                          <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                          <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                             <b>&gt;</b>
                           </a>
                         </j:when>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -3,7 +3,7 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%All Configuration History}">
 
-    <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css"/>
+    <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css" />
 
     <l:side-panel>
       <l:tasks>
@@ -16,9 +16,9 @@
       </l:tasks>
     </l:side-panel>
 
-    <j:set var="requestUrl" value="${rootURL}${request.getPathInfo().toString()}"/>
-    <j:set var="filter" value="${request.getParameter('filter')}"/>
-    <j:set var="filter" value="${filter == null ? 'system' : filter}"/>
+    <j:set var="requestUrl" value="${rootURL}${request.getPathInfo().toString()}" />
+    <j:set var="filter" value="${request.getParameter('filter')}" />
+    <j:set var="filter" value="${filter == null ? 'system' : filter}" />
 
     <j:choose>
       <j:when test="${filter == 'all'}">
@@ -40,25 +40,25 @@
 
     <l:main-panel>
 
-      <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}"/>
-      <j:set var="pageNum" value="${request.getParameter('pageNum')}"/>
-      <j:set var="entriesPerPage" value="${request.getParameter('entriesPerPage')}"/>
-      <j:set var="totalEntriesNumber" value="${it.getRevisionAmount()}"/>
-      <j:set var="defaultEntriesPerPage" value="${(defaultEntriesPerPage > totalEntriesNumber) ? &quot;all&quot; : defaultEntriesPerPage}"/>
+      <j:set var="defaultEntriesPerPage" value="${it.getMaxEntriesPerPage()}" />
+      <j:set var="pageNum" value="${request.getParameter('pageNum')}" />
+      <j:set var="entriesPerPage" value="${request.getParameter('entriesPerPage')}" />
+      <j:set var="totalEntriesNumber" value="${it.getRevisionAmount()}" />
+      <j:set var="defaultEntriesPerPage" value="${(defaultEntriesPerPage > totalEntriesNumber) ? &quot;all&quot; : defaultEntriesPerPage}" />
       <j:if test="${pageNum == null or pageNum.equals(&quot;&quot;)}">
-        <j:set var="pageNum" value="0"/>
+        <j:set var="pageNum" value="0" />
       </j:if>
       <j:if test="${entriesPerPage == null or entriesPerPage.equals(&quot;&quot;)}">
-        <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}"/>
+        <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}" />
       </j:if>
       <j:choose>
         <j:when test="${entriesPerPage.equals(&quot;all&quot;) or filter.equals(&quot;created&quot;)}">
           <j:set var="configs" value="${it.getConfigs()}" />
-          <j:set var="maxPageNum" value="${0}"/>
+          <j:set var="maxPageNum" value="${0}" />
         </j:when>
         <j:otherwise>
           <j:set var="configs" value="${it.getConfigs(pageNum*entriesPerPage, pageNum*entriesPerPage+entriesPerPage)}" />
-          <j:set var="maxPageNum" value="${it.getMaxPageNum()}"/>
+          <j:set var="maxPageNum" value="${it.getMaxPageNum()}" />
         </j:otherwise>
       </j:choose>
 
@@ -67,19 +67,19 @@
         <j:choose>
           <j:when test="${!it.hasConfigurePermission() and (filter == 'system' || filter == null)}">
             ${%No permission to view system changes}
-          </j:when>
+</j:when>
           <j:when test="${!it.hasJobConfigurePermission() and !it.hasReadExtensionPermission()}">
             ${%No permission to view config history}
-          </j:when>
+</j:when>
           <j:when test="${configs.size() == 0}">
             ${%No configuration history available}
-          </j:when>
+</j:when>
           <j:otherwise>
             <div>
               <table class="jenkins-table sortable" style="width:100%;">
                 <thead>
                   <tr style="position:sticky; top:66px;">
-                    <th initialSortDir="up" >${%Date}</th>
+                    <th initialSortDir="up">${%Date}</th>
                     <j:choose>
                       <j:when test="${filter == 'jobs' || filter == 'deleted' || filter == 'created'}">
                         <th>${%Job configuration}</th>
@@ -102,9 +102,9 @@
                   </tr>
                 </thead>
 
-                <j:set var="configNr" value="0"/>
+                <j:set var="configNr" value="0" />
                 <j:forEach var="config" items="${configs}">
-                  <j:set var="configNr" value="${configNr + 1}"/>
+                  <j:set var="configNr" value="${configNr + 1}" />
                   <tr class="alternate">
                     <td>${config.date}</td>
                     <j:choose>
@@ -120,28 +120,35 @@
                       <j:otherwise>
                         <j:choose>
                           <j:when test="${config.job.contains('_deleted_')}">
-                            <td><a href="history?name=${config.job}" id="deleted">${config.job}</a></td>
+                            <td>
+                              <a href="history?name=${config.job}" id="deleted">${config.job}</a>
+                            </td>
                           </j:when>
                           <j:otherwise>
-                            <td><a href="history?name=${config.job}">${config.job}</a>&amp;nbsp;(system)</td>
+                            <td>
+                              <a href="history?name=${config.job}">${config.job}</a>
+                              &amp;nbsp;(system)
+                            </td>
                           </j:otherwise>
                         </j:choose>
                       </j:otherwise>
                     </j:choose>
                     <td>${config.operation}</td>
                     <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
-                      <td><a href="${rootURL}/user/${config.userID}">${config.userID}</a></td>
+                      <td>
+                        <a href="${rootURL}/user/${config.userID}">${config.userID}</a>
+                      </td>
                     </j:if>
                     <td>
                       <!-- TODO check whether job has a JobConfigHistoryProjectAction before hyperlinking -->
-                      <a href="${it.createLinkToFiles(config,'xml')}"> ${%View as XML} </a>
+                      <a href="${it.createLinkToFiles(config,'xml')}"> ${%View as XML}</a>
                       <st:nbsp />
                       <a href="${it.createLinkToFiles(config,'raw')}">
                         (${%RAW})
-                      </a>
+</a>
                     </td>
                     <j:if test="${filter == 'deleted'}">
-                      <td  style="text-align:center">
+                      <td style="text-align:center">
                         <j:if test="${it.getLastAvailableConfigXml(config.getJob()) != null}">
                           <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
                             <!--this prevents people from destroying their history by trying to restore deleted folder jobs
@@ -160,13 +167,13 @@
                   </tr>
                 </j:forEach>
               </table>
-              <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}"/>
+              <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
               <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
               <f:bottomButtonBar>
                 <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
-                    <!-- Page view filter selector -->
-                    <div>
-                      <j:if test="${!filter.equals(&quot;created&quot;)}">
+                  <!-- Page view filter selector -->
+                  <div>
+                    <j:if test="${!filter.equals(&quot;created&quot;)}">
                       <h3>${%Entries per page}:</h3>
                       <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
                         <j:choose>
@@ -178,57 +185,57 @@
                           </j:otherwise>
                         </j:choose>
                       </j:forEach>
-                      </j:if>
-                    </div>
+                    </j:if>
+                  </div>
 
-                    <!--page navigation-->
-                    <div>
-                      <j:if test="${maxPageNum != 0}">
-                          <h3>${%Page}:</h3>
+                  <!--page navigation-->
+                  <div>
+                    <j:if test="${maxPageNum != 0}">
+                      <h3>${%Page}:</h3>
 
-                          <!--"<" for one step back-->
-                          <j:choose>
-                            <j:when test="${pageNum > 0}">
-                              <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                <b>&lt;</b>
-                              </a>
-                            </j:when>
-                            <j:otherwise>
-                              <a class="jenkins-button" rel="noopener noreferrer">
-                                <b>&lt;</b>
-                              </a>
-                            </j:otherwise>
-                          </j:choose>
+                      <!--"<" for one step back-->
+                      <j:choose>
+                        <j:when test="${pageNum > 0}">
+                          <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                            <b>&lt;</b>
+                          </a>
+                        </j:when>
+                        <j:otherwise>
+                          <a class="jenkins-button" rel="noopener noreferrer">
+                            <b>&lt;</b>
+                          </a>
+                        </j:otherwise>
+                      </j:choose>
 
-                          <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
-                          <j:forEach var="currentPageNum" items="${relevantPageNums}">
-                            <j:choose>
-                              <j:when test="${currentPageNum == pageNum}">
-                                <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
+                      <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
+                      <j:forEach var="currentPageNum" items="${relevantPageNums}">
+                        <j:choose>
+                          <j:when test="${currentPageNum == pageNum}">
+                            <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>
-                              </j:when>
-                              <j:otherwise>
-                                <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                          </j:when>
+                          <j:otherwise>
+                            <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>
-                              </j:otherwise>
-                            </j:choose>
-                          </j:forEach>
+                          </j:otherwise>
+                        </j:choose>
+                      </j:forEach>
 
-                          <!--">" for one step forward-->
-                          <j:choose>
-                            <j:when test="${maxPageNum > pageNum}">
-                              <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                <b>&gt;</b>
-                              </a>
-                            </j:when>
-                            <j:otherwise>
-                              <a class="jenkins-button" rel="noopener noreferrer">
-                                <b>&gt;</b>
-                              </a>
-                            </j:otherwise>
-                          </j:choose>
-                      </j:if>
-                    </div>
+                      <!--">" for one step forward-->
+                      <j:choose>
+                        <j:when test="${maxPageNum > pageNum}">
+                          <a class="jenkins-button" href="${requestUrl}?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                            <b>&gt;</b>
+                          </a>
+                        </j:when>
+                        <j:otherwise>
+                          <a class="jenkins-button" rel="noopener noreferrer">
+                            <b>&gt;</b>
+                          </a>
+                        </j:otherwise>
+                      </j:choose>
+                    </j:if>
+                  </div>
                 </div>
               </f:bottomButtonBar>
 


### PR DESCRIPTION
This plugin base on many different sub pages. 
I want to update style for job config history. 
This will set up direction where those tables should be converted.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

![image](https://user-images.githubusercontent.com/9051964/172248651-9f25fc76-42f1-4c93-9689-e48c96260db7.png)
