### PR TITLE
Remove inline security warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@ Job Configuration History Plugin
 
 Saves copies of all job and system configurations.
 
-Older versions of this plugin may not be safe to use. Please review the following warnings before using an older version:
-* [Reflected Cross Site Scripting vulnerability](https://jenkins.io/security/advisory/2018-09-25/#SECURITY-1130)
-
 This plugin saves **a copy of the configuration file** of jobs and agents (`config.xml`) for every change made and of the system configuration (`<config-name>.xml`).
 You can also see what changes have been made by which user if you configured a security policy.
 


### PR DESCRIPTION
This is just an artifact of the wiki migration, a macro added that to wiki pages, now we have plugins.jenkins.io for that.

Origin branch (I'm lazy and GH doesn't offer org owners to fork), please delete on merge.