### PR TITLE
fix: add missing dots to project and root config table button bar

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -186,6 +186,11 @@
                           <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
                           <j:forEach var="currentPageNum" items="${relevantPageNums}">
                             <j:choose>
+                              <j:when test="${currentPageNum == -1}">
+                                <a class="jenkins-button" rel="noopener noreferrer">
+                                  <b>&#8230;</b>
+                                </a>
+                              </j:when>
                               <j:when test="${currentPageNum == pageNum}">
                                 <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -178,6 +178,11 @@
 
                       <!--"<" for one step back-->
                       <j:choose>
+                        <j:when test="${currentPageNum == -1}">
+                          <a class="jenkins-button" rel="noopener noreferrer">
+                            <b>&#8230;</b>
+                          </a>
+                        </j:when>
                         <j:when test="${pageNum > 0}">
                           <a class="jenkins-button" href="?name=${name}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                             <b>&lt;</b>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -178,11 +178,6 @@
 
                       <!--"<" for one step back-->
                       <j:choose>
-                        <j:when test="${currentPageNum == -1}">
-                          <a class="jenkins-button" rel="noopener noreferrer">
-                            <b>&#8230;</b>
-                          </a>
-                        </j:when>
                         <j:when test="${pageNum > 0}">
                           <a class="jenkins-button" href="?name=${name}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
                             <b>&lt;</b>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -198,13 +198,18 @@
                       <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
                       <j:forEach var="currentPageNum" items="${relevantPageNums}">
                         <j:choose>
+                          <j:when test="${currentPageNum == -1}">
+                            <a class="jenkins-button" rel="noopener noreferrer">
+                              <b>&#8230;</b>
+                            </a>
+                          </j:when>
                           <j:when test="${currentPageNum == pageNum}">
                             <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
-                                  ${currentPageNum+1}</a>
+                              ${currentPageNum+1}</a>
                           </j:when>
                           <j:otherwise>
                             <a class="jenkins-button" href="?name=${name}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                  ${currentPageNum+1}</a>
+                              ${currentPageNum+1}</a>
                           </j:otherwise>
                         </j:choose>
                       </j:forEach>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -202,6 +202,11 @@
                       <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
                       <j:forEach var="currentPageNum" items="${relevantPageNums}">
                         <j:choose>
+                          <j:when test="${currentPageNum == -1}">
+                            <a class="jenkins-button" rel="noopener noreferrer">
+                              <b>&#8230;</b>
+                            </a>
+                          </j:when>
                           <j:when test="${currentPageNum == pageNum}">
                             <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
                                   ${currentPageNum+1}</a>


### PR DESCRIPTION
Last changes introduced small bug.
There is no `...` when bigger ranges are used.

Before:
![image](https://user-images.githubusercontent.com/9051964/184317740-0a4b7558-6c03-42b7-a098-849ea4737c40.png)

After:
![image](https://user-images.githubusercontent.com/9051964/184322772-a8ebae10-40d5-427d-b99c-4f2bdf0956e9.png)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Relevant PR's:
https://github.com/jenkinsci/job-config-history-plugin/pull/223
https://github.com/jenkinsci/job-config-history-plugin/pull/202
https://github.com/jenkinsci/job-config-history-plugin/pull/199

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
