### PR TITLE
[JENKINS-68863] Add null check to JobConfigHistorySaveableListener to avoid race condition during boot

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistorySaveableListener.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistorySaveableListener.java
@@ -56,7 +56,7 @@ public class JobConfigHistorySaveableListener extends SaveableListener {
     public void onChange(final Saveable o, final XmlFile file) {
         final JobConfigHistory plugin = getPlugin();
         LOG.log(FINEST, "In onChange for {0}", o);
-        if (plugin.isSaveable(o, file) && !PluginUtils.isUserExcluded(plugin)) {
+        if (plugin != null && plugin.isSaveable(o, file) && !PluginUtils.isUserExcluded(plugin)) {
             final HistoryDao configHistoryListenerHelper = getHistoryDao(
                     plugin);
             configHistoryListenerHelper.saveItem(file);


### PR DESCRIPTION
There is an apparent race condition that was preventing my Jenkins instance from booting. Adding this check turns `onChange` into a no-op when `getPlugin()` returns `null`. I am unsure if this should be amended to also include a logging message when the `plugin` is indeed `null`.

Relevant issues:

- [JENKINS-68863](https://issues.jenkins.io/browse/JENKINS-68863)

Relevant pull requests:

- None that I know of

Tests:

- This is my first time contributing here. Would it be appropriate to add a simple test that just forces `getPlugin()` to return `null`? 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
