### PR TITLE
[JENKINS-70002] Fix the width of the pagination buttons

### DIFF
--- a/src/main/resources/components/entries-per-page.jelly
+++ b/src/main/resources/components/entries-per-page.jelly
@@ -1,0 +1,21 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+    <div>
+        <j:if test="${!filter.equals(&quot;created&quot;)}">
+            <h3 class="jenkins-!-margin-bottom-2">${%Entries per page}:</h3>
+
+            <div class="jch-entries-per-page">
+                <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
+                    <j:choose>
+                        <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
+                            <a class="jenkins-button jenkins-button--primary" href="?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                        </j:when>
+                        <j:otherwise>
+                            <a class="jenkins-button jenkins-button--tertiary" href="?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
+                        </j:otherwise>
+                    </j:choose>
+                </j:forEach>
+            </div>
+        </j:if>
+    </div>
+</j:jelly>

--- a/src/main/resources/components/pagination.jelly
+++ b/src/main/resources/components/pagination.jelly
@@ -1,0 +1,57 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout">
+    <div>
+        <j:if test="${maxPageNum != 0}">
+            <h3 class="jenkins-!-margin-bottom-2">${%Page}:</h3>
+
+            <div class="jch-pagination">
+                <!--"<" for one step back-->
+                <j:choose>
+                    <j:when test="${pageNum > 0}">
+                        <a class="jenkins-button jenkins-button--tertiary" href="?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                            <l:icon src="symbol-chevron-back-outline plugin-ionicons-api" />
+                        </a>
+                    </j:when>
+                    <j:otherwise>
+                        <a class="jenkins-button jenkins-button--tertiary" rel="noopener noreferrer">
+                            <l:icon src="symbol-chevron-back-outline plugin-ionicons-api" />
+                        </a>
+                    </j:otherwise>
+                </j:choose>
+
+                <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
+                <j:forEach var="currentPageNum" items="${relevantPageNums}">
+                    <j:choose>
+                        <j:when test="${currentPageNum == -1}">
+                            <a class="jenkins-button jenkins-button--tertiary" rel="noopener noreferrer">
+                                <b>&#8230;</b>
+                            </a>
+                        </j:when>
+                        <j:when test="${currentPageNum == pageNum}">
+                            <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
+                                ${currentPageNum+1}</a>
+                        </j:when>
+                        <j:otherwise>
+                            <a class="jenkins-button jenkins-button--tertiary" href="?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                                ${currentPageNum+1}</a>
+                        </j:otherwise>
+                    </j:choose>
+                </j:forEach>
+
+                <!--">" for one step forward-->
+                <j:choose>
+                    <j:when test="${maxPageNum > pageNum}">
+                        <a class="jenkins-button jenkins-button--tertiary" href="?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
+                            <l:icon src="symbol-chevron-forward-outline plugin-ionicons-api" />
+                        </a>
+                    </j:when>
+                    <j:otherwise>
+                        <a class="jenkins-button jenkins-button--tertiary" rel="noopener noreferrer">
+                            <l:icon src="symbol-chevron-forward-outline plugin-ionicons-api" />
+                        </a>
+                    </j:otherwise>
+                </j:choose>
+            </div>
+        </j:if>
+    </div>
+</j:jelly>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:c="/components" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%Job Configuration History}">
 
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css" />
@@ -147,86 +147,13 @@
                 <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
                 <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
                 <f:bottomButtonBar>
-                  <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
+                  <c:entries-per-page />
+                  <c:pagination />
 
-                    <!-- Page view filter selector -->
-                    <div>
-                      <h3>${%Entries per page}:</h3>
-                      <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
-                        <j:choose>
-                          <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
-                            <a class="jenkins-button jenkins-button--primary" href="?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
-                          </j:when>
-                          <j:otherwise>
-                            <a class="jenkins-button" href="?pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
-                          </j:otherwise>
-                        </j:choose>
-                      </j:forEach>
-                    </div>
-                    <div style="display: flex; justify-content: flex-end">
-                      <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
-                      <div>
-                        <j:if test="${maxPageNum != 0}">
-                          <h3>${%Page}:</h3>
-
-                          <!--"<" for one step back-->
-                          <j:choose>
-                            <j:when test="${pageNum > 0}">
-                              <a class="jenkins-button" href="?pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                <b>&lt;</b>
-                              </a>
-                            </j:when>
-                            <j:otherwise>
-                              <a class="jenkins-button" rel="noopener noreferrer">
-                                <b>&lt;</b>
-                              </a>
-                            </j:otherwise>
-                          </j:choose>
-
-                          <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
-                          <j:forEach var="currentPageNum" items="${relevantPageNums}">
-                            <j:choose>
-                              <j:when test="${currentPageNum == -1}">
-                                <a class="jenkins-button" rel="noopener noreferrer">
-                                  <b>&#8230;</b>
-                                </a>
-                              </j:when>
-                              <j:when test="${currentPageNum == pageNum}">
-                                <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
-                                  ${currentPageNum+1}</a>
-                              </j:when>
-                              <j:otherwise>
-                                <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                  ${currentPageNum+1}</a>
-                              </j:otherwise>
-                            </j:choose>
-                          </j:forEach>
-
-                          <!--">" for one step forward-->
-                          <j:choose>
-                            <j:when test="${maxPageNum > pageNum}">
-                              <a class="jenkins-button" href="?pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                <b>&gt;</b>
-                              </a>
-                            </j:when>
-                            <j:otherwise>
-                              <a class="jenkins-button" rel="noopener noreferrer">
-                                <b>&gt;</b>
-                              </a>
-                            </j:otherwise>
-                          </j:choose>
-                        </j:if>
-                      </div>
-
-                      <!-- Show Diff -->
-                      <div style="align-self: flex-end">
-                        <j:if test="${configs.size() > 1}">
-                          <button class="jenkins-button">${%Show Diffs}</button>
-                        </j:if>
-                      </div>
-                    </div>
-
-                  </div>
+                  <!-- Show Diff -->
+                  <j:if test="${configs.size() > 1}">
+                    <button class="jenkins-button">${%Show Diffs}</button>
+                  </j:if>
                 </f:bottomButtonBar>
               </form>
             </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -2,7 +2,7 @@
 <j:jelly xmlns:j="jelly:core"
   xmlns:st="jelly:stapler"
   xmlns:l="/lib/layout"
-  xmlns:f="/lib/form">
+  xmlns:f="/lib/form" xmlns:c="/components">
   <l:layout title="${%Job Configuration History}">
 
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css" />
@@ -159,103 +159,11 @@
 
             <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
             <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
+
             <f:bottomButtonBar>
-              <div style="display: flex; justify-content: space-between; flex-flow: row wrap;" class="jenkins-buttons-row">
-                <div style="flex-direction: column; display: flex; justify-content: space-between">
-                  <!-- Page view filter selector -->
-                  <!-- <j:if test="${!filter.equals(&quot;created&quot;)}"> -->
-                  <div>
-                    <h3>${%Entries per page}:</h3>
-                  </div>
-                  <div>
-                    <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
-                      <j:choose>
-                        <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
-                          <a class="jenkins-button jenkins-button--primary" href="?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
-                        </j:when>
-                        <j:otherwise>
-                          <a class="jenkins-button" href="?name=${name}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
-                        </j:otherwise>
-                      </j:choose>
-                    </j:forEach>
-                  </div>
-                </div>
-                <div style="display: flex; justify-content: space-between; flex-flow: row wrap;">
-                  <div style="flex-flow: column wrap">
-                    <!--page navigation: "[ < 1 ... 5 6 7 8 9 ... 20 > ]"-->
-                    <j:if test="${maxPageNum != 0}">
-                      <h3>${%Page}:</h3>
-
-                      <!--"<" for one step back-->
-                      <j:choose>
-                        <j:when test="${pageNum > 0}">
-                          <a class="jenkins-button" href="?name=${name}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                            <b>&lt;</b>
-                          </a>
-                        </j:when>
-                        <j:otherwise>
-                          <a class="jenkins-button" rel="noopener noreferrer">
-                            <b>&lt;</b>
-                          </a>
-                        </j:otherwise>
-                      </j:choose>
-
-                      <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
-                      <j:forEach var="currentPageNum" items="${relevantPageNums}">
-                        <j:choose>
-                          <j:when test="${currentPageNum == -1}">
-                            <a class="jenkins-button" rel="noopener noreferrer">
-                              <b>&#8230;</b>
-                            </a>
-                          </j:when>
-                          <j:when test="${currentPageNum == pageNum}">
-                            <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
-                              ${currentPageNum+1}</a>
-                          </j:when>
-                          <j:otherwise>
-                            <a class="jenkins-button" href="?name=${name}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                              ${currentPageNum+1}</a>
-                          </j:otherwise>
-                        </j:choose>
-                      </j:forEach>
-
-                      <!--">" for one step forward-->
-                      <j:choose>
-                        <j:when test="${maxPageNum > pageNum}">
-                          <a class="jenkins-button" href="?name=${name}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                            <b>&gt;</b>
-                          </a>
-                        </j:when>
-                        <j:otherwise>
-                          <a class="jenkins-button" rel="noopener noreferrer">
-                            <b>&gt;</b>
-                          </a>
-                        </j:otherwise>
-                      </j:choose>
-                    </j:if>
-                  </div>
-                  <div style="display: flex; justify-content: space-between; align-items: space-between; flex-flow: column-reverse wrap">
-
-                    <!-- Show Diff -->
-                    <j:if test="${configs.size() > 1}">
-                      <button type="submit" form="rootHistoryDiffForm" style="align-self: stretch" class="jenkins-button">${%Show Diffs}</button>
-                    </j:if>
-
-                    <!-- Restore Project -->
-                    <!-- this prevents people from destroying their history by trying to restore deleted folder jobs -->
-                    <!-- TODO: Fix that. (see code)-->
-                    <!-- Restore button (visible only after deletion) -->
-                    <j:if test="${isDeleted and (configs.size() > 1) and configs.get(0).job.replace('/jobs', '/job').equals(configs.get(0).job)}">
-                      <form id="rootHistoryRestoreProjectForm" method="post" action="forwardToRestoreQuestion?name=${name}" name="forward">
-                        <button type="submit" form="rootHistoryRestoreProjectForm" style="align-self: stretch" class="jenkins-button">${%Restore project}</button>
-                      </form>
-                    </j:if>
-                  </div>
-                </div>
-
-              </div>
+              <c:entries-per-page />
+              <c:pagination />
             </f:bottomButtonBar>
-
           </j:otherwise>
         </j:choose>
       </div>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:c="/components" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
   <l:layout title="${%All Configuration History}">
 
     <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/jobConfigHistory/css/style.css" />
@@ -49,6 +49,7 @@
       <j:if test="${entriesPerPage == null or entriesPerPage.equals(&quot;&quot;)}">
         <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}" />
       </j:if>
+
       <j:choose>
         <j:when test="${entriesPerPage.equals(&quot;all&quot;) or filter.equals(&quot;created&quot;)}">
           <j:set var="configs" value="${it.getConfigs()}" />
@@ -59,6 +60,9 @@
           <j:set var="maxPageNum" value="${it.getMaxPageNum()}" />
         </j:otherwise>
       </j:choose>
+
+      <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
+      <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
 
       <div>
         <j:choose>
@@ -157,84 +161,10 @@
                 </j:forEach>
               </table>
 
-              <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
-              <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
-
               <f:bottomButtonBar>
-                <div style="display: flex; justify-content: space-between; align-items: flex-end" class="jenkins-buttons-row">
-                  <!-- Page view filter selector -->
-                  <div>
-                    <j:if test="${!filter.equals(&quot;created&quot;)}">
-                      <h3>${%Entries per page}:</h3>
-                      <j:forEach var="entryPerPageVal" items="${entryPerPageArray}">
-                        <j:choose>
-                          <j:when test="${entriesPerPage.equals(entryPerPageVal)}">
-                            <a class="jenkins-button jenkins-button--primary" href="?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
-                          </j:when>
-                          <j:otherwise>
-                            <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${0}&amp;entriesPerPage=${entryPerPageVal}" rel="noopener noreferrer">${entryPerPageVal}</a>
-                          </j:otherwise>
-                        </j:choose>
-                      </j:forEach>
-                    </j:if>
-                  </div>
-
-                  <!--page navigation-->
-                  <div>
-                    <j:if test="${maxPageNum != 0}">
-                      <h3>${%Page}:</h3>
-
-                      <!--"<" for one step back-->
-                      <j:choose>
-                        <j:when test="${pageNum > 0}">
-                          <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${pageNum-1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                            <b>&lt;</b>
-                          </a>
-                        </j:when>
-                        <j:otherwise>
-                          <a class="jenkins-button" rel="noopener noreferrer">
-                            <b>&lt;</b>
-                          </a>
-                        </j:otherwise>
-                      </j:choose>
-
-                      <!--page navigation: "1 ... 5 6 7 8 9 ... 20"-->
-                      <j:forEach var="currentPageNum" items="${relevantPageNums}">
-                        <j:choose>
-                          <j:when test="${currentPageNum == -1}">
-                            <a class="jenkins-button" rel="noopener noreferrer">
-                              <b>&#8230;</b>
-                            </a>
-                          </j:when>
-                          <j:when test="${currentPageNum == pageNum}">
-                            <a class="jenkins-button jenkins-button--primary" rel="noopener noreferrer">
-                                  ${currentPageNum+1}</a>
-                          </j:when>
-                          <j:otherwise>
-                            <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${currentPageNum}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                                  ${currentPageNum+1}</a>
-                          </j:otherwise>
-                        </j:choose>
-                      </j:forEach>
-
-                      <!--">" for one step forward-->
-                      <j:choose>
-                        <j:when test="${maxPageNum > pageNum}">
-                          <a class="jenkins-button" href="?filter=${filter}&amp;pageNum=${pageNum+1}&amp;entriesPerPage=${entriesPerPage}" rel="noopener noreferrer">
-                            <b>&gt;</b>
-                          </a>
-                        </j:when>
-                        <j:otherwise>
-                          <a class="jenkins-button" rel="noopener noreferrer">
-                            <b>&gt;</b>
-                          </a>
-                        </j:otherwise>
-                      </j:choose>
-                    </j:if>
-                  </div>
-                </div>
+                <c:entries-per-page />
+                <c:pagination />
               </f:bottomButtonBar>
-
             </div>
           </j:otherwise>
         </j:choose>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/index.jelly
@@ -49,7 +49,6 @@
       <j:if test="${entriesPerPage == null or entriesPerPage.equals(&quot;&quot;)}">
         <j:set var="entriesPerPage" value="${defaultEntriesPerPage.toString()}" />
       </j:if>
-
       <j:choose>
         <j:when test="${entriesPerPage.equals(&quot;all&quot;) or filter.equals(&quot;created&quot;)}">
           <j:set var="configs" value="${it.getConfigs()}" />
@@ -60,9 +59,6 @@
           <j:set var="maxPageNum" value="${it.getMaxPageNum()}" />
         </j:otherwise>
       </j:choose>
-
-      <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
-      <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
 
       <div>
         <j:choose>
@@ -160,6 +156,9 @@
                   </tr>
                 </j:forEach>
               </table>
+
+              <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
+              <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
 
               <f:bottomButtonBar>
                 <c:entries-per-page />

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -631,3 +631,18 @@ table.no-borders-warning caption {
 
     border-radius:2px;
 }
+
+.bottom-sticker-inner {
+    align-items: end;
+}
+
+.jch-entries-per-page, .jch-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3125rem;
+}
+
+.jch-entries-per-page .jenkins-button, .jch-pagination .jenkins-button {
+    min-width: 52px;
+}

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -633,6 +633,8 @@ table.no-borders-warning caption {
 }
 
 .bottom-sticker-inner {
+    display: flex;
+    justify-content: start;
     align-items: end;
 }
 

--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -634,7 +634,7 @@ table.no-borders-warning caption {
 
 .bottom-sticker-inner {
     display: flex;
-    justify-content: start;
+    justify-content: space-between;
     align-items: end;
 }
 


### PR DESCRIPTION
**Before**
![](https://issues.jenkins.io/secure/attachment/59425/Zrzut%20ekranu%202022-11-03%20101214.png)

**After**
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/43062514/203169103-7ddb2abe-ac62-4690-a1d3-906d247476d3.png">

Adds components for the entries-per-page/pagination controls so they're not duplicated + fixes the styling of them so that the buttons aren't super large and blocky.