### PR TITLE
[JENKINS-70740] Fix JobconfigHistory circular dependency source

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/PluginUtils.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/PluginUtils.java
@@ -23,6 +23,7 @@
  */
 package hudson.plugins.jobConfigHistory;
 
+import hudson.ExtensionList;
 import hudson.Plugin;
 import hudson.model.User;
 import hudson.security.ACL;
@@ -55,7 +56,7 @@ final public class PluginUtils {
      * @return plugin
      */
     public static JobConfigHistory getPlugin() {
-        return GlobalConfiguration.all().get(JobConfigHistory.class);
+        return ExtensionList.lookupSingleton(JobConfigHistory.class);
     }
 
     /**


### PR DESCRIPTION
[JENKINS-70740](https://issues.jenkins.io/browse/JENKINS-70740) fix a potential source of circular dependency. 

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

****

Tested this with this scenario:

**Reproduce**

* Spin up Jenkins 2.392
* install Job Config History latest public version
* install Prometheus Plugin
* Stop Jenkins
* Start Jenkins
* --> notice the circular dependency exception

**Test fix**

* Spin up Jenkins 2.392
* install Job Config History snapshot
* install Prometheus Plugin
* Stop Jenkins
* Start Jenkins
* startup is clean