### PR TITLE
EOL JSR 305

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryActionFactory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryActionFactory.java
@@ -28,7 +28,7 @@ import hudson.model.AbstractItem;
 import hudson.model.Action;
 import jenkins.model.TransientActionFactory;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.logging.Level;
@@ -59,7 +59,7 @@ public class JobConfigHistoryActionFactory
      * {@inheritDoc}
      */
     @Override
-    public Collection<? extends Action> createFor(@Nonnull AbstractItem target) {
+    public Collection<? extends Action> createFor(@NonNull AbstractItem target) {
         final JobConfigHistoryProjectAction newAction = new JobConfigHistoryProjectAction(
                 target);
         LOG.log(Level.FINE, "{0} adds {1} for {2}",


### PR DESCRIPTION
Several years ago, Jenkins core switched from the abandoned JSR 305 annotations to SpotBugs annotations, but this plugin never caught up. This PR adapts this plugin to the common convention used in Jenkins core and the vast majority of other Jenkins plugins.