### PR TITLE
fix: Make preformatted html less blocky

### DIFF
--- a/src/main/webapp/css/style.css
+++ b/src/main/webapp/css/style.css
@@ -648,3 +648,8 @@ table.no-borders-warning caption {
 .jch-entries-per-page .jenkins-button, .jch-pagination .jenkins-button {
     min-width: 52px;
 }
+
+.jch pre {
+  background-color: var(--white);
+  padding: 0.1rem;
+}


### PR DESCRIPTION
A UI refresh to Jenkins made the `<pre>` look blocky. While that works for most of the other parts of Jenkins, it does not suit what this plugin does.

This change makes it go back to the more traditional look of this plugin.

Before
![image](https://github.com/jenkinsci/job-config-history-plugin/assets/193047/f9ae318a-c1b9-449b-a52d-f24a210c8274)

After
![image](https://github.com/jenkinsci/job-config-history-plugin/assets/193047/fa1dae2b-ab90-42be-8e7e-a99f8cecc5fd)


<!-- Please describe your pull request here. -->

### Testing done

All existing tests pass when running `mvn verify`

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
