### PR TITLE
Clear reason before rendering config page

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobLocalConfiguration.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobLocalConfiguration.java
@@ -29,7 +29,7 @@ public class JobLocalConfiguration extends JobProperty<Job<?, ?>> {
     }
 
     public String getChangeReasonComment() {
-        return changeReasonComment;
+        return "";
     }
 
     @Extension


### PR DESCRIPTION
Before this, it would render the last entered reasons. If the user forgot to change the reason before hitting save, they would see the old reason in the history.

This makes it so you see no reason specified, which is more correct than the older reason.

<!-- Please describe your pull request here. -->

Existing tests work. When using this feature, any reason specified correctly shows up in the changelog.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
