### PR TITLE
Optimize `JobLocalConfiguration`

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/FileHistoryDao.java
@@ -376,6 +376,7 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
                     new Object[]{JobConfigHistoryConsts.JOB_LOCAL_CONFIGURATION_XML_TAG, configFile.getFile()});
             return Optional.empty();
         } else if (jobLocalConfigurationNodes.getLength() == 1) {
+            // Tag is found. Content ought to be nonempty (see JobLocalConfiguration.DescriptorImpl.newInstance).
             org.w3c.dom.Node jobLocalConfiguration = jobLocalConfigurationNodes.item(0);
             NodeList jlcChildren = jobLocalConfiguration.getChildNodes();
             org.w3c.dom.Node changeReasonCommentNode = null;
@@ -386,7 +387,6 @@ public class FileHistoryDao extends JobConfigHistoryStrategy
                 }
             }
             if (changeReasonCommentNode != null) {
-                //tag is found. Might contain no comment (getTextContent() returns "").
                 String changeReasonComment = changeReasonCommentNode.getTextContent();
                 if (changeReasonComment != null) {
                     //delete jobLocalConfiguration node from document

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobLocalConfiguration.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobLocalConfiguration.java
@@ -8,6 +8,7 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -46,6 +47,12 @@ public class JobLocalConfiguration extends JobProperty<Job<?, ?>> {
 
         public boolean isApplicable(AbstractProject<?, ?> item) {
             return true;
+        }
+
+        @Override
+        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            JobLocalConfiguration jp = (JobLocalConfiguration) super.newInstance(req, formData);
+            return StringUtils.isBlank(jp.changeReasonComment) ? null : jp;
         }
 
         public boolean configure(StaplerRequest request, JSONObject jsonObject) throws FormException {


### PR DESCRIPTION
Amends #113, which was rewriting every job `config.xml` during every save, even in the normal case that `changeReasonComment` was left blank. Noticed because the `config.xml` was being left in a half-written state on occasion; using `AtomicFileWriter` would help, though better still would be to use a different system entirely for recording change reason comments (like just keeping this information in memory).