### PR TITLE
[JENKINS-70655] Re-Add missing diff button and restore its function

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -163,6 +163,12 @@
             <f:bottomButtonBar>
               <c:entries-per-page />
               <c:pagination />
+
+              <!-- Show Diff -->
+              <j:if test="${configs.size() > 1}">
+                <button class="jenkins-button">${%Show Diffs}</button>
+              </j:if>
+
             </f:bottomButtonBar>
           </j:otherwise>
         </j:choose>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryRootAction/history.jelly
@@ -155,21 +155,21 @@
 
                 </tbody>
               </table>
+
+              <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
+              <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
+
+              <f:bottomButtonBar>
+                <c:entries-per-page />
+                <c:pagination />
+
+                <!-- Show Diff -->
+                <j:if test="${configs.size() > 1}">
+                      <button class="jenkins-button">${%Show Diffs}</button>
+                </j:if>
+              </f:bottomButtonBar>
             </f:form>
 
-            <j:set var="relevantPageNums" value="${it.getRelevantPageNums(pageNum*1)}" />
-            <j:set var="entryPerPageArray" value="10, 25, 100, 250, ${%all}" />
-
-            <f:bottomButtonBar>
-              <c:entries-per-page />
-              <c:pagination />
-
-              <!-- Show Diff -->
-              <j:if test="${configs.size() > 1}">
-                <button class="jenkins-button">${%Show Diffs}</button>
-              </j:if>
-
-            </f:bottomButtonBar>
           </j:otherwise>
         </j:choose>
       </div>


### PR DESCRIPTION
After refactoring jelly part of functionality get lost.
This PR restores the lost `Show diff` button inside root config files comparison. 

### Connected issues

https://issues.jenkins.io/browse/JENKINS-71440
https://issues.jenkins.io/browse/JENKINS-71942
https://issues.jenkins.io/browse/JENKINS-70682
https://issues.jenkins.io/browse/JENKINS-70655

### Testing done

I tested this manually with the `mvn hpi:run` command.

BEFORE:
![Screenshot 2024-09-13 at 13 28 55](https://github.com/user-attachments/assets/f6d80b1a-9d82-4392-b466-9b34d7c895cd)

AFTER:
![image](https://github.com/user-attachments/assets/e8a90310-c525-4ce3-bd2e-a9cb4bb17b82)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
