### PR TITLE
[Jenkins-68742] Fixed Job Config History Badge Visibility

### DIFF
--- a/src/test/resources/hudson/plugins/jobConfigHistory/configuration-as-code-default-expected.yml
+++ b/src/test/resources/hudson/plugins/jobConfigHistory/configuration-as-code-default-expected.yml
@@ -1,6 +1,6 @@
 excludePattern: "queue\\.xml|nodeMonitors\\.xml|UpdateCenter\\.xml|global-build-stats|LockableResourcesManager\\\
   .xml|MilestoneStep\\.xml|cloudbees-disk-usage-simple\\.xml"
 saveModuleConfiguration: false
-showBuildBadges: "always"
+showBuildBadges: "userWithConfigPermission"
 showChangeReasonCommentWindow: true
 skipDuplicateHistory: true


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

[Closes ](https://issues.jenkins.io/browse/JENKINS-68742)

Changed the default hardcoded value of "showBuildBadges" from "always" to "userWithConfigPermission" this will only allow the users who have the job config permission to be able to view the config widget as the requirement. I've also modified some test cases to work with these changes.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
