### PR TITLE
Fixed TimeZone test case Issue in different environments

### DIFF
--- a/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/FileHistoryDaoTest.java
@@ -54,6 +54,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
 import java.util.SortedMap;
+import java.util.TimeZone;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -153,6 +154,9 @@ public class FileHistoryDaoTest {
     @Test
     public void testGetIdFormatter() {
         SimpleDateFormat result = FileHistoryDao.getIdFormatter();
+        // setting a default timezone to avoid timezone issues in different environments
+        result.setTimeZone(TimeZone.getTimeZone("UTC"));
+        
         final String formattedDate = result.format(new Date(0));
         // workaround for timezone issues, as cloudbees is in the far east :-)
         // and returns 1969 :-).


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done
Fix timezone issue in FileHistoryDaoTest by setting UTC on formatter instead of relying on system timezone

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
