### PR TITLE
[Jenkins-68742] Fixed Job Config History Badge Link Visibility

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigBadgeAction.java
@@ -87,6 +87,16 @@ public class JobConfigBadgeAction implements BuildBadgeAction, RunAction2 {
     }
 
     /**
+     * Returns true if the config change build badges link should appear (depending
+     * on plugin settings and user permissions). Called from badge.jelly.
+     *
+     * @return True if badges link should appear.
+     */
+    public boolean showBadgeLink() {
+        return getPlugin().showBuildBadgesLink(build.getParent());
+    }
+
+    /**
      * Check if the config history files that are attached to the build still
      * exist.
      *

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -405,7 +405,7 @@ public class JobConfigHistory extends GlobalConfiguration {
         if (showBuildBadges.equals("never")) {
             return false;
         }
-        return project.hasPermission(Item.CONFIGURE) || getJenkins().hasPermission(Jenkins.ADMINISTER);
+        return project.hasPermission(Item.CONFIGURE);
     }
 
     /**

--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistory.java
@@ -395,6 +395,20 @@ public class JobConfigHistory extends GlobalConfiguration {
     }
 
     /**
+     * Whether build badges link should appear for the builds of this project.
+     *
+     * @param project The project to which the build history belongs.
+     * @return False if the option is set to 'never', 'always' or the user doesn't have
+     * the required permissions.
+     */
+    public boolean showBuildBadgesLink(Job<?, ?> project) {
+        if (showBuildBadges.equals("never")) {
+            return false;
+        }
+        return project.hasPermission(Item.CONFIGURE) || getJenkins().hasPermission(Jenkins.ADMINISTER);
+    }
+
+    /**
      * Gets the regular expression pattern used by this class.
      *
      * @return The loaded regexp pattern, or null if pattern was invalid.

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigBadgeAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigBadgeAction/badge.jelly
@@ -4,13 +4,13 @@
     <j:if test="${it.showBadgeLink()}">
       <a href="${it.createLink()}" style="text-decoration: none">
         <span class="icon-sm">
-          <l:icon id="showDiff" src="${it.getIcon()}" title="${it.getTooltip()}" />
+          <l:icon id="showDiff" src="${it.getIcon()}" tooltip="${it.getTooltip()}" />
         </span>
       </a>
     </j:if>
     <j:if test="${!it.showBadgeLink()}">
       <span class="icon-sm">
-        <l:icon id="showDiff" src="${it.getIcon()}" title="${it.getTooltip()}" />
+        <l:icon id="showDiff" src="${it.getIcon()}" tooltip="${it.getTooltip()}" />
       </span>
     </j:if>
   </j:if>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigBadgeAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigBadgeAction/badge.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <j:if test="${it.showBadge() and it.oldConfigsExist()}">
     <j:if test="${it.showBadgeLink()}">

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigBadgeAction/badge.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigBadgeAction/badge.jelly
@@ -1,10 +1,16 @@
-<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <j:if test="${it.showBadge() and it.oldConfigsExist()}">
-    <a href="${it.createLink()}" style="text-decoration: none">
+    <j:if test="${it.showBadgeLink()}">
+      <a href="${it.createLink()}" style="text-decoration: none">
+        <span class="icon-sm">
+          <l:icon id="showDiff" src="${it.getIcon()}" title="${it.getTooltip()}" />
+        </span>
+      </a>
+    </j:if>
+    <j:if test="${!it.showBadgeLink()}">
       <span class="icon-sm">
         <l:icon id="showDiff" src="${it.getIcon()}" title="${it.getTooltip()}" />
       </span>
-    </a>
+    </j:if>
   </j:if>
 </j:jelly>

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigBadgeActionTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigBadgeActionTest.java
@@ -93,6 +93,16 @@ public class JobConfigBadgeActionTest {
     }
 
     @Test
+    public void testShowBadgeLink() throws Exception {
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject("Test1");
+        jenkinsRule.buildAndAssertSuccess(project);
+        Run<FreeStyleProject, FreeStyleBuild> build = project.getBuilds().getLastBuild();
+
+        sut.onAttached(build);
+        assertTrue(sut.showBadgeLink());
+    }
+
+    @Test
     public void testOldConfigsExist() throws Exception {
         FreeStyleProject project = jenkinsRule.createFreeStyleProject("Test1");
         jenkinsRule.buildAndAssertSuccess(project);

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryTest.java
@@ -31,6 +31,7 @@ import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
 import hudson.model.TopLevelItem;
 import hudson.util.FormValidation;
+import hudson.model.Item;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.junit.Rule;
@@ -243,6 +244,30 @@ public class JobConfigHistoryTest {
         unauthorizedSut.setShowBuildBadges("adminUser");
         assertTrue(sut.showBuildBadges(freeStyleProject));
         assertFalse(unauthorizedSut.showBuildBadges(freeStyleProject));
+    }
+
+    @Test
+    public void testShowBuildBadgesLink() throws IOException {
+        AbstractProject<?, ?> mockedProject = mock(AbstractProject.class);
+
+        when(mockedProject.hasPermission(Item.CONFIGURE)).thenReturn(true, false);
+
+        JobConfigHistory sut = createSut();
+        JobConfigHistory unauthorizedSut = createUnauthorizedSut();
+
+
+        // showBuildBadges set to 'never'
+        sut.setShowBuildBadges("never");
+        assertFalse(sut.showBuildBadgesLink(mockedProject));
+
+        // showBuildBadges set to either 'always', 'userWithConfigPermission' or 'admin'
+        sut.setShowBuildBadges("always");
+
+        // should return True as user have config permission
+        assertTrue(sut.showBuildBadgesLink(mockedProject));
+
+        // should return False as user do not have config permission
+        assertFalse(unauthorizedSut.showBuildBadgesLink(mockedProject));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done
[Closes](https://issues.jenkins.io/browse/JENKINS-68742)

Modified the visibility of the link of the Job Config Badge Link. Previously anyone can click on the Job Config Badge Link if the badge was visible. Now, the link can only be accessible if user have job config permission. Refer to [this](https://github.com/jenkinsci/job-config-history-plugin/pull/350#issuecomment-2580882712) 

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
