### PR TITLE
`Job Configuration Difference` page links to wrong user

### DIFF
--- a/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/ComputerConfigHistoryAction/showDiffFiles.jelly
@@ -129,7 +129,7 @@
                         <div><b>${%Operation}:</b> <span class="describedElement">${it.getOperation(2)}</span></div>
                         <div>
                             <b>${%User}:</b>
-                            <a class="url-button" href="${rootURL}/user/${it.getUserID(1)}">${it.getUser(2)}</a>
+                            <a class="url-button" href="${rootURL}/user/${it.getUserID(2)}">${it.getUser(2)}</a>
                         </div>
                       </div>
                     </th>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/JobConfigHistoryProjectAction/showDiffFiles.jelly
@@ -142,7 +142,7 @@
                         <div>
                           <j:if test="${it.hasConfigurePermission() || it.hasJobConfigurePermission()}">
                             <b>${%User}:</b>
-                            <a class="url-button" href="${rootURL}/user/${it.getUserID(1)}">${it.getUser(2)}</a>
+                            <a class="url-button" href="${rootURL}/user/${it.getUserID(2)}">${it.getUser(2)}</a>
                           </j:if>
 
                         </div>


### PR DESCRIPTION
The `Job Configuration Difference` diffs two job configurations, listing the date, user etc of each configuration.

The second configuration (`Newer Change`) lists the second user, but the corresponding link is to the _first_ configurations' user profile.