### PR TITLE
Fix ComputerHistoryListener integration test

### DIFF
--- a/src/test/java/hudson/plugins/jobConfigHistory/ComputerHistoryListenerIT.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/ComputerHistoryListenerIT.java
@@ -98,8 +98,8 @@ public class ComputerHistoryListenerIT {
         Slave agentThree = rule.createOnlineSlave();
         HtmlForm form = rule.createWebClient().getPage(agentTwo, "configure")
                 .getFormByName("config");
-        HtmlInput element = form.getInputByName("_.nodeDescription");
-        element.setValue("Node description");
+        HtmlInput element = form.getInputByName("_.numExecutors");
+        element.setValue("5");
         rule.submit(form);
         JobConfigHistoryStrategy dao = PluginUtils.getHistoryDao();
         assertEquals(


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR fixes the currently broken ComputerHistoryListener integration test. I stumbled over this, while
working on another PR that adds an option to make change reason messages mandatory.
### What changed
The test originally used a change of the field `nodeDescription` which has evolved into a CodeMirror field that cannot be queried or set by HtmlUnit anymore. Therefore, this PR changes the field to be modified to `numExecutors` which is still a regular input.

### Testing done

ran all integration tests with `mvn test -Dtest=**/*IT`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
