### PR TITLE
[JENKINS-76018] fix broken node xml after new node creation

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/NodeLocalConfiguration.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/NodeLocalConfiguration.java
@@ -75,7 +75,7 @@ public class NodeLocalConfiguration extends NodeProperty<Node> {
             if (isApplicable(n)) {
                 lastChangeReasonCommentByNode.put(n, Util.fixEmptyAndTrim(nlc.changeReasonComment));
             }
-            return null;
+            return nlc;
         }
 
         @Override

--- a/src/main/resources/hudson/plugins/jobConfigHistory/NodeLocalConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/NodeLocalConfiguration/config.jelly
@@ -1,13 +1,16 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  <j:if test="${descriptor.isDialogEnabled()}">
-    <f:invisibleEntry>
-      <f:textbox field="changeReasonComment" clazz="change-reason-comment ignore-dirty"
-        data-mandatory="${descriptor.getChangeReasonCommentIsMandatory()}"
-        data-dialog-message="${%Please provide a change message}"
-        data-dialog-cancel="${%Cancel}"
-        data-dialog-optional="(${%optional})"/>
-    </f:invisibleEntry>
+  <div class="change-reason-container"
+       data-mandatory="${descriptor.getChangeReasonCommentIsMandatory()}"
+       data-dialog-message="${%Please provide a change message}"
+       data-dialog-cancel="${%Cancel}"
+       data-dialog-optional="(${%optional})"
+       data-enabled="${descriptor.isDialogEnabled()}">
+    <j:if test="${descriptor.isDialogEnabled()}">
+      <f:invisibleEntry>
+        <f:textbox field="changeReasonComment" clazz="change-reason-comment ignore-dirty"/>
+      </f:invisibleEntry>
+    </j:if>
     <st:adjunct includes="hudson.plugins.jobConfigHistory.mandatory-config-reason-onlycomputer"/>
-  </j:if>
+  </div>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/jobConfigHistory/mandatory-config-reason-onlycomputer.js
+++ b/src/main/resources/hudson/plugins/jobConfigHistory/mandatory-config-reason-onlycomputer.js
@@ -6,9 +6,11 @@ window.jchpLib = window.jchpLib || {
     'mandatory': false,
     'dlgMsg': 'defaultDialogMessage',
     'dlgCancel': 'defaultCancel',
+    'disabled': false,
 
     'init': function(e) {
-        this.reason = e;
+        this.reason = e.querySelector("INPUT.change-reason-comment");
+        this.disabled = e.dataset.enabled == 'false';
         this.mandatory = e.dataset.mandatory == 'true';
         this.dlgMsg = e.dataset.dialogMessage;
         if (!this.mandatory) {
@@ -17,18 +19,17 @@ window.jchpLib = window.jchpLib || {
         this.dlgCancel = e.dataset.dialogCancel;
         // Hide corresponding parent optional container in node config and check the
         // corresponding checkbox in order to get the change message actually submitted.
-        var p = e.parentElement;
-        while (null != p) {
-            if (p.classList.contains('optionalBlock-container') && p.tagName == 'DIV') {
-                p.style.display = 'none';
-                var cb = p.querySelector('INPUT.optional-block-control');
-                if (null != cb) {
-                    cb.checked = true;
-                    cb.dispatchEvent(new Event('click'));
-                }
-                break;
+        var p = e.closest('DIV.optionalBlock-container');
+        if (p != null) {
+            p.style.display = 'none';
+            var cb = p.querySelector('INPUT.optional-block-control');
+            if (null != cb) {
+              if (e.dataset.enabled == 'true') {
+                cb.checked = true;
+              } else {
+                cb.checked = false;
+              }
             }
-            p = p.parentElement;
         }
     },
 
@@ -42,6 +43,9 @@ window.jchpLib = window.jchpLib || {
     },
 
     'handleClick': function(e) {
+        if (this.disabled) {
+          return;
+        }
         var button = e.target;
         var isSubmit = button.classList.contains('jenkins-submit-button');
         if (this.reasonNeedsReset) {
@@ -81,7 +85,7 @@ window.jchpLib = window.jchpLib || {
     }
 };
 
-Behaviour.specify('INPUT.change-reason-comment', 'ConfigHistoryInit', -999, function (e) {
+Behaviour.specify('DIV.change-reason-container', 'ConfigHistoryInit', -999, function (e) {
     jchpLib.init.bind(jchpLib)(e);
 });
 


### PR DESCRIPTION
The node configuration is broken with Jenkins 2.594.3 or older when the dialog is enabled.
Also fix the UI when the change message dialog is disabled
[JENKINS-76018](https://issues.jenkins.io/browse/JENKINS-76018)

<!-- Please describe your pull request here. -->
Before:
<img width="622" height="248" alt="image" src="https://github.com/user-attachments/assets/03660c58-b024-4b85-92fe-62dce17ab8a5" />

After:
<img width="469" height="214" alt="image" src="https://github.com/user-attachments/assets/bad2f1f0-bf85-4cfc-9821-726530cf2452" />


### Testing done
Verified that creating a new new produces valid xml

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
