### PR TITLE
Fix JENKINS-61199: enforce retention for deleted jobs

### DIFF
--- a/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
+++ b/src/main/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurger.java
@@ -134,6 +134,7 @@ public class JobConfigHistoryPurger extends PeriodicWork {
     void purgeHistoryByAge() {
         purgeSystemOrJobHistory(overviewHistoryDao.getSystemConfigs());
         purgeSystemOrJobHistory(overviewHistoryDao.getJobs(""));
+        purgeSystemOrJobHistory(overviewHistoryDao.getDeletedJobs(""));
     }
 
     /**

--- a/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurgerTest.java
+++ b/src/test/java/hudson/plugins/jobConfigHistory/JobConfigHistoryPurgerTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,6 +124,34 @@ class JobConfigHistoryPurgerTest {
         File[] itemDirs = {newFolder};
         sut.purgeSystemOrJobHistory(itemDirs);
         assertTrue(newFolder.exists());
+    }
+
+
+    @Test
+    void testPurgeHistoryByAgeIncludesDeletedJobs() {
+        File[] systemDirs = { new File("sys") };
+        File[] jobDirs = { new File("job") };
+        File[] deletedJobDirs = { new File("job_deleted_20200101_000000_000") };
+
+        when(mockedOverviewDao.getSystemConfigs()).thenReturn(systemDirs);
+        when(mockedOverviewDao.getJobs("")).thenReturn(jobDirs);
+        when(mockedOverviewDao.getDeletedJobs("")).thenReturn(deletedJobDirs);
+
+        List<File[]> purged = new ArrayList<>();
+
+        JobConfigHistoryPurger sut = new JobConfigHistoryPurger(mockedPlugin, mockedDao, mockedOverviewDao) {
+            @Override
+            void purgeSystemOrJobHistory(File[] itemDirs) {
+                purged.add(itemDirs);
+            }
+        };
+
+        sut.purgeHistoryByAge();
+
+        assertEquals(3, purged.size());
+        assertTrue(purged.contains(systemDirs));
+        assertTrue(purged.contains(jobDirs));
+        assertTrue(purged.contains(deletedJobDirs));
     }
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Fixes **JENKINS-61199**: retention by age wasn’t applied to deleted jobs.  
`JobConfigHistoryPurger.purgeHistoryByAge()` only purged `getJobs("")`, which excludes `*_deleted_*` roots.  
This PR adds a purge pass over deleted jobs via `getDeletedJobs("")`, without changing behavior for normal jobs.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
